### PR TITLE
Clean up

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,21 +1,93 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Main where
+module Main (main) where
+
 import           Cardano.Api hiding (TxId)
-import           Options.Generic
-import           Canonical.AlwaysSucceed
-import           Canonical.ConfigurationNft
-import           Canonical.Vote
-import           Canonical.Treasury
+import           Options.Generic 
+  ( Generic
+  , ParseRecord
+  , ParseField
+  , ParseFields
+  , getRecord
+  , getOnly
+  , lispCaseModifiers
+  , parseRecord
+  , parseRecordWithModifiers
+  , parseField
+  , parseFields
+  , readField
+  )
+import           Canonical.AlwaysSucceed (succeed, succeed1, succeedHash, succeedHash1)
+import           Canonical.ConfigurationNft 
+  ( ConfigurationValidatorConfig
+      ( ConfigurationValidatorConfig
+      , cvcConfigNftCurrencySymbol
+      , cvcConfigNftTokenName
+      )
+  , NftConfig(NftConfig, ncTokenName, ncInitialUtxo)
+  , configurationScript 
+  , configurationValidatorHash
+  , nftMinterPolicyId
+  , nftMinter
+  )
+import           Canonical.Vote 
+  ( VoteMinterConfig(..)
+  , VoteValidatorConfig(..)
+  , voteScript
+  , voteMinter
+  , voteMinterPolicyId
+  , voteValidatorHash
+  )
+import           Canonical.Treasury 
+  ( TreasuryValidatorConfig(..)
+  , treasuryScript 
+  , treasuryValidatorHash
+  )
 import           Canonical.Tally
-import           Prelude
-import           Plutus.V1.Ledger.Bytes
-import           Plutus.V1.Ledger.Crypto
-import           Plutus.V1.Ledger.Scripts
-import           Plutus.V1.Ledger.Tx
-import           Plutus.V1.Ledger.Value
-import           Data.String
+  ( TallyNftConfig(..) 
+  , TallyValidatorConfig(..) 
+  , IndexNftConfig(..)
+  , IndexValidatorConfig(..)
+  , indexScript
+  , indexValidatorHash
+  , tallyIndexNftMinter
+  , tallyIndexNftMinterPolicyId
+  , tallyNftMinter
+  , tallyNftMinterPolicyId
+  , tallyScript
+  , tallyValidatorHash
+  )
+import           Prelude 
+  ( IO 
+  , Either(Left, Right) 
+  , Integer
+  , FilePath
+  , Maybe(Nothing)
+  , Show
+  , Read
+  , fmap
+  , read
+  , readsPrec
+  , print
+  , putStrLn
+  , show
+  , span
+  , tail
+  , writeFile
+  , ($)
+  , (<$>)
+  , (>>=)
+  , (=<<)
+  , (++)
+  , (/=)
+  )
+import           Plutus.V1.Ledger.Bytes (getLedgerBytes)
+import           Plutus.V1.Ledger.Crypto (PubKeyHash)
+import           Plutus.V1.Ledger.Scripts (ValidatorHash)
+import           Plutus.V1.Ledger.Tx (TxOutRef(TxOutRef), TxId(TxId))
+import           Plutus.V1.Ledger.Value (TokenName)
+import           Data.String (fromString)
 
 instance Read TokenName where
   readsPrec _ x = [(fromString x, "")]

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,93 +1,120 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Main (main) where
 
-import           Cardano.Api hiding (TxId)
-import           Options.Generic 
-  ( Generic
-  , ParseRecord
-  , ParseField
-  , ParseFields
-  , getRecord
-  , getOnly
-  , lispCaseModifiers
-  , parseRecord
-  , parseRecordWithModifiers
-  , parseField
-  , parseFields
-  , readField
-  )
-import           Canonical.AlwaysSucceed (succeed, succeed1, succeedHash, succeedHash1)
-import           Canonical.ConfigurationNft 
-  ( ConfigurationValidatorConfig
-      ( ConfigurationValidatorConfig
-      , cvcConfigNftCurrencySymbol
-      , cvcConfigNftTokenName
-      )
-  , NftConfig(NftConfig, ncTokenName, ncInitialUtxo)
-  , configurationScript 
-  , configurationValidatorHash
-  , nftMinterPolicyId
-  , nftMinter
-  )
-import           Canonical.Vote 
-  ( VoteMinterConfig(..)
-  , VoteValidatorConfig(..)
-  , voteScript
-  , voteMinter
-  , voteMinterPolicyId
-  , voteValidatorHash
-  )
-import           Canonical.Treasury 
-  ( TreasuryValidatorConfig(..)
-  , treasuryScript 
-  , treasuryValidatorHash
-  )
-import           Canonical.Tally
-  ( TallyNftConfig(..) 
-  , TallyValidatorConfig(..) 
-  , IndexNftConfig(..)
-  , IndexValidatorConfig(..)
-  , indexScript
-  , indexValidatorHash
-  , tallyIndexNftMinter
-  , tallyIndexNftMinterPolicyId
-  , tallyNftMinter
-  , tallyNftMinterPolicyId
-  , tallyScript
-  , tallyValidatorHash
-  )
-import           Prelude 
-  ( IO 
-  , Either(Left, Right) 
-  , Integer
-  , FilePath
-  , Maybe(Nothing)
-  , Show
-  , Read
-  , fmap
-  , read
-  , readsPrec
-  , print
-  , putStrLn
-  , show
-  , span
-  , tail
-  , writeFile
-  , ($)
-  , (<$>)
-  , (>>=)
-  , (=<<)
-  , (++)
-  , (/=)
-  )
-import           Plutus.V1.Ledger.Bytes (getLedgerBytes)
-import           Plutus.V1.Ledger.Crypto (PubKeyHash)
-import           Plutus.V1.Ledger.Scripts (ValidatorHash)
-import           Plutus.V1.Ledger.Tx (TxOutRef(TxOutRef), TxId(TxId))
-import           Plutus.V1.Ledger.Value (TokenName)
-import           Data.String (fromString)
+import Canonical.AlwaysSucceed (succeed, succeed1, succeedHash, succeedHash1)
+import Canonical.ConfigurationNft (
+  ConfigurationValidatorConfig (
+    ConfigurationValidatorConfig,
+    cvcConfigNftCurrencySymbol,
+    cvcConfigNftTokenName
+  ),
+  NftConfig (NftConfig, ncInitialUtxo, ncTokenName),
+  configurationScript,
+  configurationValidatorHash,
+  nftMinter,
+  nftMinterPolicyId,
+ )
+import Canonical.Tally (
+  IndexNftConfig (IndexNftConfig, incIndexValidator, incInitialUtxo, incTokenName),
+  IndexValidatorConfig (
+    IndexValidatorConfig,
+    ivcConfigNftCurrencySymbol,
+    ivcConfigNftTokenName,
+    ivcNonce
+  ),
+  TallyNftConfig (
+    TallyNftConfig,
+    tncConfigNftCurrencySymbol,
+    tncConfigNftTokenName,
+    tncIndexNftPolicyId,
+    tncIndexNftTokenName
+  ),
+  TallyValidatorConfig (
+    TallyValidatorConfig,
+    tvcConfigNftCurrencySymbol,
+    tvcConfigNftTokenName
+  ),
+  indexScript,
+  indexValidatorHash,
+  tallyIndexNftMinter,
+  tallyIndexNftMinterPolicyId,
+  tallyNftMinter,
+  tallyNftMinterPolicyId,
+  tallyScript,
+  tallyValidatorHash,
+ )
+import Canonical.Treasury (
+  TreasuryValidatorConfig (
+    TreasuryValidatorConfig,
+    tvcConfigNftCurrencySymbol,
+    tvcConfigNftTokenName
+  ),
+  treasuryScript,
+  treasuryValidatorHash,
+ )
+import Canonical.Vote (
+  VoteMinterConfig (
+    VoteMinterConfig,
+    vmcConfigNftCurrencySymbol,
+    vmcConfigNftTokenName
+  ),
+  VoteValidatorConfig (
+    VoteValidatorConfig,
+    vvcConfigNftCurrencySymbol,
+    vvcConfigNftTokenName
+  ),
+  voteMinter,
+  voteMinterPolicyId,
+  voteScript,
+  voteValidatorHash,
+ )
+import Cardano.Api hiding (TxId)
+import Data.String (fromString)
+import Options.Generic (
+  Generic,
+  ParseField,
+  ParseFields,
+  ParseRecord,
+  getOnly,
+  getRecord,
+  lispCaseModifiers,
+  parseField,
+  parseFields,
+  parseRecord,
+  parseRecordWithModifiers,
+  readField,
+ )
+import Plutus.V1.Ledger.Bytes (getLedgerBytes)
+import Plutus.V1.Ledger.Crypto (PubKeyHash)
+import Plutus.V1.Ledger.Scripts (ValidatorHash)
+import Plutus.V1.Ledger.Tx (TxId (TxId), TxOutRef (TxOutRef))
+import Plutus.V1.Ledger.Value (TokenName)
+import Prelude (
+  Either (Left, Right),
+  FilePath,
+  IO,
+  Integer,
+  Maybe (Nothing),
+  Read,
+  Show,
+  fmap,
+  print,
+  putStrLn,
+  read,
+  readsPrec,
+  show,
+  span,
+  tail,
+  writeFile,
+  ($),
+  (++),
+  (/=),
+  (<$>),
+  (=<<),
+  (>>=),
+ )
 
 instance Read TokenName where
   readsPrec _ x = [(fromString x, "")]
@@ -100,39 +127,40 @@ instance Read ValidatorHash where
   readsPrec _ x = [(fromString x, "")]
 
 instance ParseRecord ValidatorHash where
-    parseRecord = fmap getOnly parseRecord
+  parseRecord = fmap getOnly parseRecord
 instance ParseField ValidatorHash
 instance ParseFields ValidatorHash
 
 data Options = Options
-  { alwaysSucceedOutput              :: FilePath
-  , alwaysSucceedHashOutput          :: FilePath
-  , alwaysSucceed1Output             :: FilePath
-  , alwaysSucceed1HashOutput         :: FilePath
-  , configurationNftOutput           :: FilePath
-  , configurationNftPolicyIdOutput   :: FilePath
-  , configurationNftTokenName        :: TokenName
-  , configurationNftInitialUtxo      :: TxOutRef
-  , configurationValidatorOutput     :: FilePath
+  { alwaysSucceedOutput :: FilePath
+  , alwaysSucceedHashOutput :: FilePath
+  , alwaysSucceed1Output :: FilePath
+  , alwaysSucceed1HashOutput :: FilePath
+  , configurationNftOutput :: FilePath
+  , configurationNftPolicyIdOutput :: FilePath
+  , configurationNftTokenName :: TokenName
+  , configurationNftInitialUtxo :: TxOutRef
+  , configurationValidatorOutput :: FilePath
   , configurationValidatorHashOutput :: FilePath
-  , voteMinterOutput                 :: FilePath
-  , voteMinterPolicyIdOutput         :: FilePath
-  , voteValidatorOutput              :: FilePath
-  , voteValidatorHashOutput          :: FilePath
-  , treasuryValidatorOutput          :: FilePath
-  , treasuryValidatorHashOutput      :: FilePath
-  , tallyIndexNftOutput              :: FilePath
-  , tallyIndexNftPolicyIdOutput      :: FilePath
-  , tallyIndexNftTokenName           :: TokenName
-  , tallyIndexNftInitialUtxo         :: TxOutRef
-  , tallyNftOutput                   :: FilePath
-  , tallyNftPolicyIdOutput           :: FilePath
-  , indexValidatorOutput             :: FilePath
-  , indexValidatorHashOutput         :: FilePath
-  , tallyValidatorOutput             :: FilePath
-  , tallyValidatorHashOutput         :: FilePath
-  , indexValidatorNonce              :: Integer
-  } deriving (Show, Generic)
+  , voteMinterOutput :: FilePath
+  , voteMinterPolicyIdOutput :: FilePath
+  , voteValidatorOutput :: FilePath
+  , voteValidatorHashOutput :: FilePath
+  , treasuryValidatorOutput :: FilePath
+  , treasuryValidatorHashOutput :: FilePath
+  , tallyIndexNftOutput :: FilePath
+  , tallyIndexNftPolicyIdOutput :: FilePath
+  , tallyIndexNftTokenName :: TokenName
+  , tallyIndexNftInitialUtxo :: TxOutRef
+  , tallyNftOutput :: FilePath
+  , tallyNftPolicyIdOutput :: FilePath
+  , indexValidatorOutput :: FilePath
+  , indexValidatorHashOutput :: FilePath
+  , tallyValidatorOutput :: FilePath
+  , tallyValidatorHashOutput :: FilePath
+  , indexValidatorNonce :: Integer
+  }
+  deriving (Show, Generic)
 
 instance ParseField PubKeyHash where
   parseField x y z w = fromString <$> parseField x y z w
@@ -148,7 +176,7 @@ instance Read TxOutRef where
   readsPrec _ s =
     let
       (x, y) = span (/= '#') s
-    in
+     in
       [(TxOutRef (TxId $ getLedgerBytes $ fromString x) $ read $ tail y, "")]
 instance ParseRecord TxOutRef where
   parseRecord = fmap getOnly parseRecord
@@ -168,8 +196,7 @@ writeSource outputPath source =
     Right () -> putStrLn $ "wrote validator to file " ++ outputPath
 
 run :: Options -> IO ()
-run Options{..} = do
-
+run Options {..} = do
   writeSource alwaysSucceedOutput succeed
 
   writeFile alwaysSucceedHashOutput $ show succeedHash
@@ -178,10 +205,11 @@ run Options{..} = do
 
   writeFile alwaysSucceed1HashOutput $ show succeedHash1
 
-  let nftConfig = NftConfig
-        { ncInitialUtxo = configurationNftInitialUtxo
-        , ncTokenName   = configurationNftTokenName
-        }
+  let nftConfig =
+        NftConfig
+          { ncInitialUtxo = configurationNftInitialUtxo
+          , ncTokenName = configurationNftTokenName
+          }
 
   writeSource configurationNftOutput $ nftMinter nftConfig
 
@@ -190,20 +218,22 @@ run Options{..} = do
   writeFile configurationNftPolicyIdOutput $ show theConfigurationNftPolicyId
 
   ----
-  let configurationValidatorConfig = ConfigurationValidatorConfig
-        { cvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
-        , cvcConfigNftTokenName      = configurationNftTokenName
-        }
+  let configurationValidatorConfig =
+        ConfigurationValidatorConfig
+          { cvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
+          , cvcConfigNftTokenName = configurationNftTokenName
+          }
 
   writeSource configurationValidatorOutput (configurationScript configurationValidatorConfig)
 
   writeFile configurationValidatorHashOutput $ show (configurationValidatorHash configurationValidatorConfig)
 
   ---
-  let voteMinterConfig = VoteMinterConfig
-        { vmcConfigNftCurrencySymbol = theConfigurationNftPolicyId
-        , vmcConfigNftTokenName      = configurationNftTokenName
-        }
+  let voteMinterConfig =
+        VoteMinterConfig
+          { vmcConfigNftCurrencySymbol = theConfigurationNftPolicyId
+          , vmcConfigNftTokenName = configurationNftTokenName
+          }
 
   writeSource voteMinterOutput (voteMinter voteMinterConfig)
 
@@ -211,29 +241,32 @@ run Options{..} = do
 
   writeFile voteMinterPolicyIdOutput $ show theVoteMinterCurrencySymbol
 
-  let voteValidatorConfig = VoteValidatorConfig
-        { vvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
-        , vvcConfigNftTokenName      = configurationNftTokenName
-        }
+  let voteValidatorConfig =
+        VoteValidatorConfig
+          { vvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
+          , vvcConfigNftTokenName = configurationNftTokenName
+          }
 
   writeSource voteValidatorOutput (voteScript voteValidatorConfig)
 
   writeFile voteValidatorHashOutput $ show (voteValidatorHash voteValidatorConfig)
 
-  let treasuryValidatorConfig = TreasuryValidatorConfig
-        { tvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
-        , tvcConfigNftTokenName      = configurationNftTokenName
-        }
+  let treasuryValidatorConfig =
+        TreasuryValidatorConfig
+          { tvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
+          , tvcConfigNftTokenName = configurationNftTokenName
+          }
 
   writeSource treasuryValidatorOutput (treasuryScript treasuryValidatorConfig)
 
   writeFile treasuryValidatorHashOutput $ show (treasuryValidatorHash treasuryValidatorConfig)
 
-  let indexValidatorConfig = IndexValidatorConfig
-        { ivcConfigNftCurrencySymbol = theConfigurationNftPolicyId
-        , ivcConfigNftTokenName      = configurationNftTokenName
-        , ivcNonce                   = indexValidatorNonce
-        }
+  let indexValidatorConfig =
+        IndexValidatorConfig
+          { ivcConfigNftCurrencySymbol = theConfigurationNftPolicyId
+          , ivcConfigNftTokenName = configurationNftTokenName
+          , ivcNonce = indexValidatorNonce
+          }
 
   writeSource indexValidatorOutput (indexScript indexValidatorConfig)
 
@@ -241,11 +274,12 @@ run Options{..} = do
 
   writeFile indexValidatorHashOutput $ show theIndexValidatorHash
 
-  let indexNftConfig = IndexNftConfig
-        { incInitialUtxo    = tallyIndexNftInitialUtxo
-        , incTokenName      = tallyIndexNftTokenName
-        , incIndexValidator = theIndexValidatorHash
-        }
+  let indexNftConfig =
+        IndexNftConfig
+          { incInitialUtxo = tallyIndexNftInitialUtxo
+          , incTokenName = tallyIndexNftTokenName
+          , incIndexValidator = theIndexValidatorHash
+          }
 
   writeSource tallyIndexNftOutput $ tallyIndexNftMinter indexNftConfig
 
@@ -253,12 +287,13 @@ run Options{..} = do
 
   writeFile tallyIndexNftPolicyIdOutput $ show theTallyIndexNftPolicyId
 
-  let tallyNftConfig = TallyNftConfig
-        { tncIndexNftPolicyId        = theTallyIndexNftPolicyId
-        , tncIndexNftTokenName       = tallyIndexNftTokenName
-        , tncConfigNftCurrencySymbol = theConfigurationNftPolicyId
-        , tncConfigNftTokenName      = configurationNftTokenName
-        }
+  let tallyNftConfig =
+        TallyNftConfig
+          { tncIndexNftPolicyId = theTallyIndexNftPolicyId
+          , tncIndexNftTokenName = tallyIndexNftTokenName
+          , tncConfigNftCurrencySymbol = theConfigurationNftPolicyId
+          , tncConfigNftTokenName = configurationNftTokenName
+          }
 
   writeSource tallyNftOutput $ tallyNftMinter tallyNftConfig
 
@@ -266,10 +301,11 @@ run Options{..} = do
 
   writeFile tallyNftPolicyIdOutput $ show theTallyNftPolicyId
 
-  let tallyValidatorConfig = TallyValidatorConfig
-        { tvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
-        , tvcConfigNftTokenName      = configurationNftTokenName
-        }
+  let tallyValidatorConfig =
+        TallyValidatorConfig
+          { tvcConfigNftCurrencySymbol = theConfigurationNftPolicyId
+          , tvcConfigNftTokenName = configurationNftTokenName
+          }
 
   writeSource tallyValidatorOutput (tallyScript tallyValidatorConfig)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -160,7 +160,7 @@ data Options = Options
   , tallyValidatorHashOutput :: FilePath
   , indexValidatorNonce :: Integer
   }
-  deriving (Show, Generic)
+  deriving stock (Show, Generic)
 
 instance ParseField PubKeyHash where
   parseField x y z w = fromString <$> parseField x y z w

--- a/cabal.project
+++ b/cabal.project
@@ -144,6 +144,11 @@ package cardano-ledger-alonzo-test
 -- --------------------------- 8< --------------------------
 -- Please do not put any `source-repository-package` clause above this line.
 
+source-repository-package
+   type: git
+   location: https://github.com/mlabs-haskell/plutus-simple-model
+   tag: 31a18e5dc28ae7620c06adfad061f06ec176346b
+
 -- Using a fork until our patches can be merged upstream
 source-repository-package
   type: git

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,20 @@
+# default.nix
+# with import <nixpkgs> {};
+# with import "github:NixOS/nixpkgs" {};
+let
+  nixpkgs = builtins.fetchTarball {
+    url    = "https://github.com/NixOS/nixpkgs/archive/0ba2543f8c855d7be8e90ef6c8dc89c1617e8a08.tar.gz";
+    sha256 = "14ann7vz7qgfrw39ji1s19n1p0likyf2ag8h7rh8iwp3iv5lmprl";
+  };
+  pkgs = import nixpkgs {};
+in pkgs.stdenv.mkDerivation {
+    name = "triphut-drv";
+    src = "./";
+    buildInputs = 
+      [ pkgs.pkg-config
+        pkgs.zlib
+        pkgs.secp256k1
+        pkgs.libsodium
+        pkgs.systemd
+      ];
+}

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,8 @@
+indentation: 2
+comma-style: leading
+record-brace-space: true
+indent-wheres: true
+diff-friendly-import-export: true
+respectful: true
+haddock-style: multi-line
+newlines-between-decls: 1

--- a/src/Canonical/AlwaysSucceed.hs
+++ b/src/Canonical/AlwaysSucceed.hs
@@ -8,8 +8,8 @@ module Canonical.AlwaysSucceed (
 import Canonical.Shared (validatorHash)
 import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
 import Codec.Serialise (serialise)
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.ByteString.Short as SBS
+import Data.ByteString.Lazy qualified as LB
+import Data.ByteString.Short qualified as SBS
 import Plutus.V1.Ledger.Scripts (Validator, ValidatorHash, mkValidatorScript)
 import Plutus.V2.Ledger.Contexts (
   ScriptContext (ScriptContext, scriptContextTxInfo),

--- a/src/Canonical/AlwaysSucceed.hs
+++ b/src/Canonical/AlwaysSucceed.hs
@@ -1,13 +1,16 @@
 module Canonical.AlwaysSucceed where
-import           Canonical.Shared
-import           Cardano.Api.Shelley (PlutusScript(..), PlutusScriptV2)
+
+import           Canonical.Shared (validatorHash)
+import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
 import           Codec.Serialise (serialise)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString.Short as SBS
-import           Plutus.V1.Ledger.Scripts
-import           Plutus.V2.Ledger.Contexts
-import           PlutusTx
-import           PlutusTx.Prelude
+import           Plutus.V1.Ledger.Scripts (Validator, ValidatorHash, mkValidatorScript)
+import           Plutus.V2.Ledger.Contexts 
+  ( TxInfo(TxInfo, txInfoId)
+  , ScriptContext(ScriptContext, scriptContextTxInfo))
+import           PlutusTx (compile, unsafeFromBuiltinData)
+import           PlutusTx.Prelude (BuiltinData, Bool(True), check, (.), ($), (==))
 
 succeedValidator :: BuiltinData -> BuiltinData -> BuiltinData -> Bool
 succeedValidator _ _ _ = True

--- a/src/Canonical/AlwaysSucceed.hs
+++ b/src/Canonical/AlwaysSucceed.hs
@@ -1,4 +1,9 @@
-module Canonical.AlwaysSucceed where
+module Canonical.AlwaysSucceed 
+  ( succeed
+  , succeed1
+  , succeedHash
+  , succeedHash1
+  ) where
 
 import           Canonical.Shared (validatorHash)
 import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)

--- a/src/Canonical/AlwaysSucceed.hs
+++ b/src/Canonical/AlwaysSucceed.hs
@@ -1,35 +1,37 @@
-module Canonical.AlwaysSucceed 
-  ( succeed
-  , succeed1
-  , succeedHash
-  , succeedHash1
-  ) where
+module Canonical.AlwaysSucceed (
+  succeed,
+  succeed1,
+  succeedHash,
+  succeedHash1,
+) where
 
-import           Canonical.Shared (validatorHash)
-import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
-import           Codec.Serialise (serialise)
+import Canonical.Shared (validatorHash)
+import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
+import Codec.Serialise (serialise)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.ByteString.Short as SBS
-import           Plutus.V1.Ledger.Scripts (Validator, ValidatorHash, mkValidatorScript)
-import           Plutus.V2.Ledger.Contexts 
-  ( TxInfo(TxInfo, txInfoId)
-  , ScriptContext(ScriptContext, scriptContextTxInfo))
-import           PlutusTx (compile, unsafeFromBuiltinData)
-import           PlutusTx.Prelude (BuiltinData, Bool(True), check, (.), ($), (==))
+import Plutus.V1.Ledger.Scripts (Validator, ValidatorHash, mkValidatorScript)
+import Plutus.V2.Ledger.Contexts (
+  ScriptContext (ScriptContext, scriptContextTxInfo),
+  TxInfo (TxInfo, txInfoId),
+ )
+import PlutusTx (compile, unsafeFromBuiltinData)
+import PlutusTx.Prelude (Bool (True), BuiltinData, check, ($), (.), (==))
 
 succeedValidator :: BuiltinData -> BuiltinData -> BuiltinData -> Bool
 succeedValidator _ _ _ = True
 
 succeedWrapped :: BuiltinData -> BuiltinData -> BuiltinData -> ()
-succeedWrapped x y z = check
-  (succeedValidator
-    (unsafeFromBuiltinData x)
-    (unsafeFromBuiltinData y)
-    (unsafeFromBuiltinData z)
-  )
+succeedWrapped x y z =
+  check
+    ( succeedValidator
+        (unsafeFromBuiltinData x)
+        (unsafeFromBuiltinData y)
+        (unsafeFromBuiltinData z)
+    )
 
 validator :: Validator
-validator = mkValidatorScript $$(PlutusTx.compile [|| succeedWrapped ||])
+validator = mkValidatorScript $$(PlutusTx.compile [||succeedWrapped||])
 
 succeed :: PlutusScript PlutusScriptV2
 succeed = PlutusScriptSerialised . SBS.toShort . LB.toStrict . serialise $ validator
@@ -41,15 +43,16 @@ succeedValidator1 :: BuiltinData -> BuiltinData -> ScriptContext -> Bool
 succeedValidator1 _ _ ScriptContext {scriptContextTxInfo = TxInfo {..}} = txInfoId == txInfoId
 
 succeedWrapped1 :: BuiltinData -> BuiltinData -> BuiltinData -> ()
-succeedWrapped1 x y z = check
-  (succeedValidator1
-    (unsafeFromBuiltinData x)
-    (unsafeFromBuiltinData y)
-    (unsafeFromBuiltinData z)
-  )
+succeedWrapped1 x y z =
+  check
+    ( succeedValidator1
+        (unsafeFromBuiltinData x)
+        (unsafeFromBuiltinData y)
+        (unsafeFromBuiltinData z)
+    )
 
 validator1 :: Validator
-validator1 = mkValidatorScript $$(PlutusTx.compile [|| succeedWrapped1 ||])
+validator1 = mkValidatorScript $$(PlutusTx.compile [||succeedWrapped1||])
 
 succeed1 :: PlutusScript PlutusScriptV2
 succeed1 = PlutusScriptSerialised . SBS.toShort . LB.toStrict . serialise $ validator1

--- a/src/Canonical/ConfigurationNft.hs
+++ b/src/Canonical/ConfigurationNft.hs
@@ -35,7 +35,7 @@ import Plutus.V1.Ledger.Credential (Credential)
 import Plutus.V1.Ledger.Crypto (PubKeyHash)
 import Plutus.V1.Ledger.Interval (before)
 import Plutus.V1.Ledger.Scripts (
-  Datum (Datum),
+  Datum,
   DatumHash,
   MintingPolicy,
   Script,
@@ -59,7 +59,7 @@ import Plutus.V2.Ledger.Contexts (
   TxInfo (TxInfo, txInfoData, txInfoInputs, txInfoMint, txInfoOutputs),
  )
 import Plutus.V2.Ledger.Tx (
-  OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash),
+  OutputDatum,
   TxOut (TxOut, txOutDatum, txOutValue),
   TxOutRef,
  )
@@ -276,12 +276,7 @@ validateConfiguration
 
       TallyState {tsProposal = proposal, ..} = case filter (hasTallyNft . cTxOutValue . cTxInInfoResolved) cTxInfoReferenceInputs of
         [] -> traceError "Missing tally NFT"
-        [ConfigurationTxInInfo {cTxInInfoResolved = ConfigurationTxOut {..}}] -> unsafeFromBuiltinData $ case cTxOutDatum of
-          OutputDatum (Datum dbs) -> dbs
-          OutputDatumHash dh -> case M.lookup dh cTxInfoData of
-            Just (Datum dbs) -> dbs
-            _ -> traceError "Missing datum"
-          NoOutputDatum -> traceError "Script input missing datum hash"
+        [ConfigurationTxInInfo {cTxInInfoResolved = ConfigurationTxOut {..}}] -> convertDatum cTxInfoData cTxOutDatum
         _ -> traceError "Too many NFT values"
 
       upgradeMinter :: CurrencySymbol

--- a/src/Canonical/ConfigurationNft.hs
+++ b/src/Canonical/ConfigurationNft.hs
@@ -28,9 +28,9 @@ import Canonical.Types (
  )
 import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
 import Codec.Serialise (serialise)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Short as BSS
-import qualified Plutonomy
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as BSS
+import Plutonomy qualified
 import Plutus.V1.Ledger.Credential (Credential)
 import Plutus.V1.Ledger.Crypto (PubKeyHash)
 import Plutus.V1.Ledger.Interval (before)
@@ -73,7 +73,7 @@ import PlutusTx (
   unstableMakeIsData,
  )
 import PlutusTx.AssocMap (Map)
-import qualified PlutusTx.AssocMap as M
+import PlutusTx.AssocMap qualified as M
 import PlutusTx.Prelude (
   Bool (False, True),
   BuiltinData,

--- a/src/Canonical/ConfigurationNft.hs
+++ b/src/Canonical/ConfigurationNft.hs
@@ -1,150 +1,152 @@
-module Canonical.ConfigurationNft 
-  ( ConfigurationValidatorConfig(..)
-  , NftConfig(..)
-  , configurationScript
-  , configurationValidator
-  , configurationValidatorHash
-  , nftMinter
-  , nftMinterPolicyId
-  , validateConfiguration
-  ) where
+module Canonical.ConfigurationNft (
+  ConfigurationValidatorConfig (..),
+  NftConfig (..),
+  configurationScript,
+  configurationValidator,
+  configurationValidatorHash,
+  nftMinter,
+  nftMinterPolicyId,
+  validateConfiguration,
+) where
 
-import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
-import           Codec.Serialise (serialise)
+import Canonical.Shared (
+  WrappedMintingPolicyType,
+  convertDatum,
+  hasSingleToken,
+  mintingPolicyHash,
+  validatorHash,
+ )
+import Canonical.Types (
+  DynamicConfig (
+    DynamicConfig,
+    dcProposalTallyEndOffset,
+    dcTallyNft,
+    dcTotalVotes,
+    dcUpgradRelativeMajorityPercent,
+    dcUpgradeMajorityPercent
+  ),
+  ProposalType (Upgrade),
+  TallyState (TallyState, tsAgainst, tsFor, tsProposal, tsProposalEndTime),
+ )
+import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
+import Codec.Serialise (serialise)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as BSS
-import           Plutus.V1.Ledger.Credential (Credential)
-import           Plutus.V1.Ledger.Crypto (PubKeyHash)
-import           Plutus.V2.Ledger.Contexts 
-  ( ScriptPurpose(Minting)
-  , ScriptContext(ScriptContext, scriptContextPurpose, scriptContextTxInfo)
-  , TxInfo(TxInfo, txInfoData, txInfoInputs, txInfoOutputs, txInfoMint)
-  , TxInInfo(txInInfoOutRef)
-  )
-import           Plutus.V1.Ledger.Interval (before)
-import           Plutus.V1.Ledger.Time (POSIXTime(POSIXTime), POSIXTimeRange)
-import           Plutus.V1.Ledger.Scripts 
-  ( Validator(Validator)
-  , ValidatorHash
-  , DatumHash
-  , Datum(Datum)
-  , MintingPolicy
-  , Script
-  , mkMintingPolicyScript
-  , unMintingPolicyScript
-  )
-import           Plutus.V2.Ledger.Tx 
-  ( TxOutRef
-  , TxOut(TxOut, txOutDatum, txOutValue)
-  , OutputDatum(OutputDatum, OutputDatumHash, NoOutputDatum)
-  )
-import           Plutus.V1.Ledger.Value 
-  ( TokenName
-  , Value(Value)
-  , CurrencySymbol
-  , mpsSymbol
-  , getValue
-  )
-import           PlutusTx 
-  ( makeLift
-  , applyCode
-  , liftCode
-  , compile
-  , unstableMakeIsData
-  , makeIsDataIndexed
-  , unsafeFromBuiltinData
-  )
-import qualified PlutusTx.AssocMap as M
-import           PlutusTx.AssocMap (Map)
-import           PlutusTx.Prelude 
-  ( BuiltinData
-  , Bool(False, True)
-  , Maybe(Just, Nothing)
-  , Integer
-  , any
-  , check
-  , divide
-  , filter
-  , traceIfFalse
-  , traceError
-  , (.)
-  , ($)
-  , (&&)
-  , (==)
-  , (>=)
-  , (+)
-  , (*)
-  )
 import qualified Plutonomy
-import           Canonical.Types 
-  ( DynamicConfig
-      ( DynamicConfig
-      , dcUpgradeMajorityPercent
-      , dcUpgradRelativeMajorityPercent
-      , dcTotalVotes
-      , dcTallyNft
-      , dcProposalTallyEndOffset
-      )
-  , TallyState(TallyState, tsFor, tsAgainst, tsProposal, tsProposalEndTime)
-  , ProposalType(Upgrade)
-  )
-import           Canonical.Shared 
-  ( WrappedMintingPolicyType
-  , hasSingleToken
-  , convertDatum
-  , mintingPolicyHash
-  , validatorHash
-  )
+import Plutus.V1.Ledger.Credential (Credential)
+import Plutus.V1.Ledger.Crypto (PubKeyHash)
+import Plutus.V1.Ledger.Interval (before)
+import Plutus.V1.Ledger.Scripts (
+  Datum (Datum),
+  DatumHash,
+  MintingPolicy,
+  Script,
+  Validator (Validator),
+  ValidatorHash,
+  mkMintingPolicyScript,
+  unMintingPolicyScript,
+ )
+import Plutus.V1.Ledger.Time (POSIXTime (POSIXTime), POSIXTimeRange)
+import Plutus.V1.Ledger.Value (
+  CurrencySymbol,
+  TokenName,
+  Value (Value),
+  getValue,
+  mpsSymbol,
+ )
+import Plutus.V2.Ledger.Contexts (
+  ScriptContext (ScriptContext, scriptContextPurpose, scriptContextTxInfo),
+  ScriptPurpose (Minting),
+  TxInInfo (txInInfoOutRef),
+  TxInfo (TxInfo, txInfoData, txInfoInputs, txInfoMint, txInfoOutputs),
+ )
+import Plutus.V2.Ledger.Tx (
+  OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash),
+  TxOut (TxOut, txOutDatum, txOutValue),
+  TxOutRef,
+ )
+import PlutusTx (
+  applyCode,
+  compile,
+  liftCode,
+  makeIsDataIndexed,
+  makeLift,
+  unsafeFromBuiltinData,
+  unstableMakeIsData,
+ )
+import PlutusTx.AssocMap (Map)
+import qualified PlutusTx.AssocMap as M
+import PlutusTx.Prelude (
+  Bool (False, True),
+  BuiltinData,
+  Integer,
+  Maybe (Just, Nothing),
+  any,
+  check,
+  divide,
+  filter,
+  traceError,
+  traceIfFalse,
+  ($),
+  (&&),
+  (*),
+  (+),
+  (.),
+  (==),
+  (>=),
+ )
 
 data NftConfig = NftConfig
   { ncInitialUtxo :: TxOutRef
-  , ncTokenName   :: TokenName
+  , ncTokenName :: TokenName
   }
 
 makeLift ''NftConfig
 
 mkNftMinter :: NftConfig -> BuiltinData -> ScriptContext -> Bool
-mkNftMinter NftConfig {..} _ ScriptContext
-  { scriptContextTxInfo = TxInfo {..}
-  , scriptContextPurpose = Minting thisCurrencySymbol
-  } =
-  let
-    hasWitness :: Value -> Bool
-    hasWitness (Value v) = case M.lookup thisCurrencySymbol v of
-      Just m -> case M.toList m of
-        [(_, c)] -> if c == 1 then True else traceError "wrong token count"
-        _ -> traceError "wrong number of tokens with policy id"
-      _ -> False
+mkNftMinter
+  NftConfig {..}
+  _
+  ScriptContext
+    { scriptContextTxInfo = TxInfo {..}
+    , scriptContextPurpose = Minting thisCurrencySymbol
+    } =
+    let
+      hasWitness :: Value -> Bool
+      hasWitness (Value v) = case M.lookup thisCurrencySymbol v of
+        Just m -> case M.toList m of
+          [(_, c)] -> if c == 1 then True else traceError "wrong token count"
+          _ -> traceError "wrong number of tokens with policy id"
+        _ -> False
 
-    hasUTxO :: Bool
-    !hasUTxO = any (\i -> txInInfoOutRef i == ncInitialUtxo) txInfoInputs
+      hasUTxO :: Bool
+      !hasUTxO = any (\i -> txInInfoOutRef i == ncInitialUtxo) txInfoInputs
 
-    -- This errors if more than one token is used as an output with this policy id
-    _newOutput :: DynamicConfig
-    !_newOutput = case filter (\TxOut {..} -> hasWitness txOutValue) txInfoOutputs of
-      [ TxOut { txOutDatum } ] -> convertDatum txInfoData txOutDatum
-      _ -> traceError "Impossible. No minted output."
+      -- This errors if more than one token is used as an output with this policy id
+      _newOutput :: DynamicConfig
+      !_newOutput = case filter (\TxOut {..} -> hasWitness txOutValue) txInfoOutputs of
+        [TxOut {txOutDatum}] -> convertDatum txInfoData txOutDatum
+        _ -> traceError "Impossible. No minted output."
 
-    onlyOneTokenMinted :: Bool
-    !onlyOneTokenMinted =
-      hasSingleToken
-        txInfoMint
-        thisCurrencySymbol
-        ncTokenName
-
-  in traceIfFalse "Missing significant UTxO!" hasUTxO
-  && traceIfFalse "Wrong mint amount!" onlyOneTokenMinted
-
+      onlyOneTokenMinted :: Bool
+      !onlyOneTokenMinted =
+        hasSingleToken
+          txInfoMint
+          thisCurrencySymbol
+          ncTokenName
+     in
+      traceIfFalse "Missing significant UTxO!" hasUTxO
+        && traceIfFalse "Wrong mint amount!" onlyOneTokenMinted
 mkNftMinter _ _ _ = traceError "wrong type of script purpose!"
 
 wrappedPolicy :: NftConfig -> WrappedMintingPolicyType
 wrappedPolicy config a b = check (mkNftMinter config a (unsafeFromBuiltinData b))
 
 policy :: NftConfig -> MintingPolicy
-policy cfg = mkMintingPolicyScript $
-  $$(compile [|| \c -> wrappedPolicy c ||])
-  `PlutusTx.applyCode`
-  PlutusTx.liftCode cfg
+policy cfg =
+  mkMintingPolicyScript $
+    $$(compile [||\c -> wrappedPolicy c||])
+      `PlutusTx.applyCode` PlutusTx.liftCode cfg
 
 plutusScript :: NftConfig -> Script
 plutusScript = unMintingPolicyScript . policy
@@ -159,11 +161,11 @@ scriptAsCbor :: NftConfig -> BSL.ByteString
 scriptAsCbor = serialise . validator
 
 nftMinter :: NftConfig -> PlutusScript PlutusScriptV2
-nftMinter
-  = PlutusScriptSerialised
-  . BSS.toShort
-  . BSL.toStrict
-  . scriptAsCbor
+nftMinter =
+  PlutusScriptSerialised
+    . BSS.toShort
+    . BSL.toStrict
+    . scriptAsCbor
 
 -------------------------------------------------------------------------------
 -- Validator
@@ -179,42 +181,42 @@ nftMinter
 -------------------------------------------------------------------------------
 
 data ConfigurationAddress = ConfigurationAddress
-  { cAddressCredential        :: Credential
+  { cAddressCredential :: Credential
   , cAddressStakingCredential :: BuiltinData
   }
 
 data ConfigurationTxOut = ConfigurationTxOut
-  { cTxOutAddress             :: ConfigurationAddress
-  , cTxOutValue               :: Value
-  , cTxOutDatum               :: OutputDatum
-  , cTxOutReferenceScript     :: BuiltinData
+  { cTxOutAddress :: ConfigurationAddress
+  , cTxOutValue :: Value
+  , cTxOutDatum :: OutputDatum
+  , cTxOutReferenceScript :: BuiltinData
   }
 
 data ConfigurationTxInInfo = ConfigurationTxInInfo
-  { cTxInInfoOutRef   :: TxOutRef
+  { cTxInInfoOutRef :: TxOutRef
   , cTxInInfoResolved :: ConfigurationTxOut
   }
 
 data ConfigurationScriptPurpose = ConfigurationSpend TxOutRef
 
 data ConfigurationScriptContext = ConfigurationScriptContext
-  { cScriptContextTxInfo  :: ConfigurationTxInfo
+  { cScriptContextTxInfo :: ConfigurationTxInfo
   , cScriptContextPurpose :: ConfigurationScriptPurpose
   }
 
 data ConfigurationTxInfo = ConfigurationTxInfo
-  { cTxInfoInputs             :: [ConfigurationTxInInfo]
-  , cTxInfoReferenceInputs    :: [ConfigurationTxInInfo]
-  , cTxInfoOutputs            :: [ConfigurationTxOut]
-  , cTxInfoFee                :: BuiltinData
-  , cTxInfoMint               :: Value
-  , cTxInfoDCert              :: BuiltinData
-  , cTxInfoWdrl               :: BuiltinData
-  , cTxInfoValidRange         :: POSIXTimeRange
-  , cTxInfoSignatories        :: [PubKeyHash]
-  , cTxInfoRedeemers          :: BuiltinData
-  , cTxInfoData               :: Map DatumHash Datum
-  , cTxInfoId                 :: BuiltinData
+  { cTxInfoInputs :: [ConfigurationTxInInfo]
+  , cTxInfoReferenceInputs :: [ConfigurationTxInInfo]
+  , cTxInfoOutputs :: [ConfigurationTxOut]
+  , cTxInfoFee :: BuiltinData
+  , cTxInfoMint :: Value
+  , cTxInfoDCert :: BuiltinData
+  , cTxInfoWdrl :: BuiltinData
+  , cTxInfoValidRange :: POSIXTimeRange
+  , cTxInfoSignatories :: [PubKeyHash]
+  , cTxInfoRedeemers :: BuiltinData
+  , cTxInfoData :: Map DatumHash Datum
+  , cTxInfoId :: BuiltinData
   }
 
 -------------------------------------------------------------------------------
@@ -223,33 +225,33 @@ data ConfigurationTxInfo = ConfigurationTxInfo
 
 data ConfigurationValidatorConfig = ConfigurationValidatorConfig
   { cvcConfigNftCurrencySymbol :: CurrencySymbol
-  , cvcConfigNftTokenName      :: TokenName
+  , cvcConfigNftTokenName :: TokenName
   }
 
 unstableMakeIsData ''ConfigurationAddress
 unstableMakeIsData ''ConfigurationTxOut
 unstableMakeIsData ''ConfigurationTxInInfo
-makeIsDataIndexed  ''ConfigurationScriptPurpose [('ConfigurationSpend,1)]
+makeIsDataIndexed ''ConfigurationScriptPurpose [('ConfigurationSpend, 1)]
 unstableMakeIsData ''ConfigurationScriptContext
 unstableMakeIsData ''ConfigurationTxInfo
 makeLift ''ConfigurationValidatorConfig
 
 ownValue :: [ConfigurationTxInInfo] -> TxOutRef -> Value
-ownValue ins txOutRef = go ins where
-  go = \case
-    [] -> traceError "The impossible happened"
-    ConfigurationTxInInfo {cTxInInfoOutRef, cTxInInfoResolved = ConfigurationTxOut{cTxOutValue}} :xs ->
-      if cTxInInfoOutRef == txOutRef then
-        cTxOutValue
-      else
-        go xs
+ownValue ins txOutRef = go ins
+  where
+    go = \case
+      [] -> traceError "The impossible happened"
+      ConfigurationTxInInfo {cTxInInfoOutRef, cTxInInfoResolved = ConfigurationTxOut {cTxOutValue}} : xs ->
+        if cTxInInfoOutRef == txOutRef
+          then cTxOutValue
+          else go xs
 
-validateConfiguration
-  :: ConfigurationValidatorConfig
-  -> DynamicConfig
-  -> BuiltinData
-  -> ConfigurationScriptContext
-  -> Bool
+validateConfiguration ::
+  ConfigurationValidatorConfig ->
+  DynamicConfig ->
+  BuiltinData ->
+  ConfigurationScriptContext ->
+  Bool
 validateConfiguration
   ConfigurationValidatorConfig {..}
   DynamicConfig {..}
@@ -258,97 +260,103 @@ validateConfiguration
     { cScriptContextTxInfo = ConfigurationTxInfo {..}
     , cScriptContextPurpose = ConfigurationSpend thisOutRef
     } =
-  let
-    thisScriptValue :: Value
-    !thisScriptValue = ownValue cTxInfoInputs thisOutRef
+    let
+      thisScriptValue :: Value
+      !thisScriptValue = ownValue cTxInfoInputs thisOutRef
 
-    hasConfigurationNft :: Bool
-    !hasConfigurationNft = case M.lookup cvcConfigNftCurrencySymbol (getValue thisScriptValue) of
-      Nothing -> False
-      Just m  -> case M.lookup cvcConfigNftTokenName m of
+      hasConfigurationNft :: Bool
+      !hasConfigurationNft = case M.lookup cvcConfigNftCurrencySymbol (getValue thisScriptValue) of
         Nothing -> False
-        Just c -> c == 1
+        Just m -> case M.lookup cvcConfigNftTokenName m of
+          Nothing -> False
+          Just c -> c == 1
 
-    hasTallyNft :: Value -> Bool
-    hasTallyNft (Value v) = case M.lookup dcTallyNft v of
-      Nothing -> False
-      Just _  -> True
+      hasTallyNft :: Value -> Bool
+      hasTallyNft (Value v) = case M.lookup dcTallyNft v of
+        Nothing -> False
+        Just _ -> True
 
-    TallyState {tsProposal = proposal ,..} = case filter (hasTallyNft . cTxOutValue . cTxInInfoResolved) cTxInfoReferenceInputs of
-      [] -> traceError "Missing tally NFT"
-      [ConfigurationTxInInfo {cTxInInfoResolved = ConfigurationTxOut {..}}] -> unsafeFromBuiltinData $ case cTxOutDatum of
-        OutputDatum (Datum dbs) -> dbs
-        OutputDatumHash dh -> case M.lookup dh cTxInfoData of
-          Just (Datum dbs) -> dbs
-          _ -> traceError "Missing datum"
-        NoOutputDatum -> traceError "Script input missing datum hash"
-      _ -> traceError "Too many NFT values"
+      TallyState {tsProposal = proposal, ..} = case filter (hasTallyNft . cTxOutValue . cTxInInfoResolved) cTxInfoReferenceInputs of
+        [] -> traceError "Missing tally NFT"
+        [ConfigurationTxInInfo {cTxInInfoResolved = ConfigurationTxOut {..}}] -> unsafeFromBuiltinData $ case cTxOutDatum of
+          OutputDatum (Datum dbs) -> dbs
+          OutputDatumHash dh -> case M.lookup dh cTxInfoData of
+            Just (Datum dbs) -> dbs
+            _ -> traceError "Missing datum"
+          NoOutputDatum -> traceError "Script input missing datum hash"
+        _ -> traceError "Too many NFT values"
 
-    upgradeMinter :: CurrencySymbol
-    upgradeMinter = case proposal of
-      Upgrade u -> u
-      _ -> traceError "Not an upgrade proposal"
+      upgradeMinter :: CurrencySymbol
+      upgradeMinter = case proposal of
+        Upgrade u -> u
+        _ -> traceError "Not an upgrade proposal"
 
-    totalVotes :: Integer
-    !totalVotes = tsFor + tsAgainst
+      totalVotes :: Integer
+      !totalVotes = tsFor + tsAgainst
 
-    relativeMajority :: Integer
-    !relativeMajority = (totalVotes * 1000) `divide` dcTotalVotes
+      relativeMajority :: Integer
+      !relativeMajority = (totalVotes * 1000) `divide` dcTotalVotes
 
-    majorityPercent :: Integer
-    !majorityPercent = (tsFor * 1000) `divide` totalVotes
+      majorityPercent :: Integer
+      !majorityPercent = (tsFor * 1000) `divide` totalVotes
 
-    hasEnoughVotes :: Bool
-    !hasEnoughVotes
-      =  traceIfFalse "relative majority is too low" (relativeMajority >= dcUpgradRelativeMajorityPercent)
-      && traceIfFalse "majority is too small" (majorityPercent >= dcUpgradeMajorityPercent)
+      hasEnoughVotes :: Bool
+      !hasEnoughVotes =
+        traceIfFalse "relative majority is too low" (relativeMajority >= dcUpgradRelativeMajorityPercent)
+          && traceIfFalse "majority is too small" (majorityPercent >= dcUpgradeMajorityPercent)
 
-    -- Make sure the upgrade token was minted
-    hasUpgradeMinterToken :: Bool
-    !hasUpgradeMinterToken = case M.lookup upgradeMinter (getValue cTxInfoMint) of
-      Nothing -> False
-      Just m  -> case M.toList m of
-        [(_, c)] -> c == 1
-        _ -> False
+      -- Make sure the upgrade token was minted
+      hasUpgradeMinterToken :: Bool
+      !hasUpgradeMinterToken = case M.lookup upgradeMinter (getValue cTxInfoMint) of
+        Nothing -> False
+        Just m -> case M.toList m of
+          [(_, c)] -> c == 1
+          _ -> False
 
-    isAfterTallyEndTime :: Bool
-    isAfterTallyEndTime = (tsProposalEndTime + POSIXTime dcProposalTallyEndOffset) `before` cTxInfoValidRange
+      isAfterTallyEndTime :: Bool
+      isAfterTallyEndTime = (tsProposalEndTime + POSIXTime dcProposalTallyEndOffset) `before` cTxInfoValidRange
+     in
+      traceIfFalse "Missing configuration nft" hasConfigurationNft
+        && traceIfFalse "The proposal doesn't have enough votes" hasEnoughVotes
+        && traceIfFalse "Not minting upgrade token" hasUpgradeMinterToken
+        && traceIfFalse "Tallying not over. Try again later" isAfterTallyEndTime
 
-  in traceIfFalse "Missing configuration nft" hasConfigurationNft
-  && traceIfFalse "The proposal doesn't have enough votes" hasEnoughVotes
-  && traceIfFalse "Not minting upgrade token" hasUpgradeMinterToken
-  && traceIfFalse "Tallying not over. Try again later" isAfterTallyEndTime
-
-wrapValidateConfiguration
-    :: ConfigurationValidatorConfig
-    -> BuiltinData
-    -> BuiltinData
-    -> BuiltinData
-    -> ()
-wrapValidateConfiguration cfg x y z = check (
-  validateConfiguration
-    cfg
-    (unsafeFromBuiltinData x)
-    (unsafeFromBuiltinData y)
-    (unsafeFromBuiltinData z) )
+wrapValidateConfiguration ::
+  ConfigurationValidatorConfig ->
+  BuiltinData ->
+  BuiltinData ->
+  BuiltinData ->
+  ()
+wrapValidateConfiguration cfg x y z =
+  check
+    ( validateConfiguration
+        cfg
+        (unsafeFromBuiltinData x)
+        (unsafeFromBuiltinData y)
+        (unsafeFromBuiltinData z)
+    )
 
 configurationValidator :: ConfigurationValidatorConfig -> Validator
-configurationValidator cfg = let
-    optimizerSettings = Plutonomy.defaultOptimizerOptions
-      { Plutonomy.ooSplitDelay = False
-      }
-  in Plutonomy.optimizeUPLCWith optimizerSettings $ Plutonomy.validatorToPlutus $ Plutonomy.mkValidatorScript $
-    $$(PlutusTx.compile [|| wrapValidateConfiguration ||])
-    `applyCode`
-    liftCode cfg
+configurationValidator cfg =
+  let
+    optimizerSettings =
+      Plutonomy.defaultOptimizerOptions
+        { Plutonomy.ooSplitDelay = False
+        }
+   in
+    Plutonomy.optimizeUPLCWith optimizerSettings $
+      Plutonomy.validatorToPlutus $
+        Plutonomy.mkValidatorScript $
+          $$(PlutusTx.compile [||wrapValidateConfiguration||])
+            `applyCode` liftCode cfg
 
 configurationValidatorHash :: ConfigurationValidatorConfig -> ValidatorHash
 configurationValidatorHash = validatorHash . configurationValidator
 
-configurationScript :: ConfigurationValidatorConfig ->  PlutusScript PlutusScriptV2
-configurationScript
-  = PlutusScriptSerialised
-  . BSS.toShort
-  . BSL.toStrict
-  . serialise
-  . configurationValidator
+configurationScript :: ConfigurationValidatorConfig -> PlutusScript PlutusScriptV2
+configurationScript =
+  PlutusScriptSerialised
+    . BSS.toShort
+    . BSL.toStrict
+    . serialise
+    . configurationValidator

--- a/src/Canonical/ConfigurationNft.hs
+++ b/src/Canonical/ConfigurationNft.hs
@@ -1,4 +1,13 @@
-module Canonical.ConfigurationNft where
+module Canonical.ConfigurationNft 
+  ( ConfigurationValidatorConfig(..)
+  , NftConfig(..)
+  , configurationScript
+  , configurationValidator
+  , configurationValidatorHash
+  , nftMinter
+  , nftMinterPolicyId
+  , validateConfiguration
+  ) where
 
 import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
 import           Codec.Serialise (serialise)

--- a/src/Canonical/ConfigurationNft.hs
+++ b/src/Canonical/ConfigurationNft.hs
@@ -10,7 +10,9 @@ module Canonical.ConfigurationNft (
 import Canonical.Shared (
   WrappedMintingPolicyType,
   convertDatum,
+  hasOneOfToken,
   hasSingleToken,
+  hasSymbolInValue,
   mintingPolicyHash,
   validatorHash,
  )
@@ -263,16 +265,10 @@ validateConfiguration
       !thisScriptValue = ownValue cTxInfoInputs thisOutRef
 
       hasConfigurationNft :: Bool
-      !hasConfigurationNft = case M.lookup cvcConfigNftCurrencySymbol (getValue thisScriptValue) of
-        Nothing -> False
-        Just m -> case M.lookup cvcConfigNftTokenName m of
-          Nothing -> False
-          Just c -> c == 1
+      !hasConfigurationNft = hasOneOfToken cvcConfigNftCurrencySymbol cvcConfigNftTokenName thisScriptValue
 
       hasTallyNft :: Value -> Bool
-      hasTallyNft (Value v) = case M.lookup dcTallyNft v of
-        Nothing -> False
-        Just _ -> True
+      hasTallyNft = hasSymbolInValue dcTallyNft
 
       TallyState {tsProposal = proposal, ..} = case filter (hasTallyNft . cTxOutValue . cTxInInfoResolved) cTxInfoReferenceInputs of
         [] -> traceError "Missing tally NFT"

--- a/src/Canonical/ConfigurationNft.hs
+++ b/src/Canonical/ConfigurationNft.hs
@@ -2,11 +2,9 @@ module Canonical.ConfigurationNft (
   ConfigurationValidatorConfig (..),
   NftConfig (..),
   configurationScript,
-  configurationValidator,
   configurationValidatorHash,
   nftMinter,
   nftMinterPolicyId,
-  validateConfiguration,
 ) where
 
 import Canonical.Shared (

--- a/src/Canonical/ConfigurationNft.hs
+++ b/src/Canonical/ConfigurationNft.hs
@@ -195,7 +195,7 @@ data ConfigurationTxInInfo = ConfigurationTxInInfo
   , cTxInInfoResolved :: ConfigurationTxOut
   }
 
-data ConfigurationScriptPurpose = ConfigurationSpend TxOutRef
+newtype ConfigurationScriptPurpose = ConfigurationSpend TxOutRef
 
 data ConfigurationScriptContext = ConfigurationScriptContext
   { cScriptContextTxInfo :: ConfigurationTxInfo

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -1,4 +1,11 @@
-module Canonical.Shared where
+module Canonical.Shared 
+  ( WrappedMintingPolicyType
+  , convertDatum 
+  , hasSingleToken
+  , mintingPolicyHash
+  , plutonomyMintingPolicyHash
+  , validatorHash 
+  ) where
 
 import           Plutus.V1.Ledger.Scripts
 import           Plutus.V1.Ledger.Value
@@ -14,21 +21,6 @@ import           Codec.Serialise (serialise)
 import qualified Plutonomy
 
 type WrappedMintingPolicyType = BuiltinData -> BuiltinData -> ()
-
-{-# INLINABLE extractDatumBytes #-}
-extractDatumBytes :: [(DatumHash, Datum)] -> DatumHash -> BuiltinData
-extractDatumBytes datums dh = getDatum $ extractDatum datums dh
-
-{-# INLINABLE extractDatum #-}
-extractDatum :: [(DatumHash, Datum)] -> DatumHash -> Datum
-extractDatum datums dh = go datums where
-  go = \case
-    [] -> traceError "Failed to find datum"
-    (x, y):xs ->
-      if x == dh then
-        y
-      else
-        go xs
 
 {-# INLINABLE hasSingleToken #-}
 hasSingleToken :: Value -> CurrencySymbol -> TokenName -> Bool

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -1,28 +1,28 @@
-module Canonical.Shared 
-  ( WrappedMintingPolicyType
-  , convertDatum 
-  , hasSingleToken
-  , mintingPolicyHash
-  , plutonomyMintingPolicyHash
-  , validatorHash 
-  ) where
+module Canonical.Shared (
+  WrappedMintingPolicyType,
+  convertDatum,
+  hasSingleToken,
+  mintingPolicyHash,
+  plutonomyMintingPolicyHash,
+  validatorHash,
+) where
 
-import           Plutus.V1.Ledger.Scripts
-import           Plutus.V1.Ledger.Value
-import           Plutus.V2.Ledger.Tx
-import           PlutusTx
-import qualified PlutusTx.AssocMap as M
-import           PlutusTx.AssocMap (Map)
-import           PlutusTx.Prelude
 import qualified Cardano.Api.Shelley as Shelly
+import Codec.Serialise (serialise)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as BSS
-import           Codec.Serialise (serialise)
 import qualified Plutonomy
+import Plutus.V1.Ledger.Scripts
+import Plutus.V1.Ledger.Value
+import Plutus.V2.Ledger.Tx
+import PlutusTx
+import PlutusTx.AssocMap (Map)
+import qualified PlutusTx.AssocMap as M
+import PlutusTx.Prelude
 
 type WrappedMintingPolicyType = BuiltinData -> BuiltinData -> ()
 
-{-# INLINABLE hasSingleToken #-}
+{-# INLINEABLE hasSingleToken #-}
 hasSingleToken :: Value -> CurrencySymbol -> TokenName -> Bool
 hasSingleToken (Value v) s t = case M.lookup s v of
   Just m -> case M.toList m of
@@ -30,7 +30,7 @@ hasSingleToken (Value v) s t = case M.lookup s v of
     _ -> traceError "wrong number of tokens with policy id"
   _ -> False
 
-{-# INLINABLE convertDatum #-}
+{-# INLINEABLE convertDatum #-}
 convertDatum :: UnsafeFromData a => Map DatumHash Datum -> OutputDatum -> a
 convertDatum infoData datum = unsafeFromBuiltinData $ case datum of
   OutputDatum (Datum dbs) -> dbs
@@ -40,40 +40,40 @@ convertDatum infoData datum = unsafeFromBuiltinData $ case datum of
   NoOutputDatum -> traceError "Missing datum hash or datum"
 
 toCardanoApiScript :: Script -> Shelly.Script Shelly.PlutusScriptV2
-toCardanoApiScript
-  = Shelly.PlutusScript Shelly.PlutusScriptV2
-  . Shelly.PlutusScriptSerialised
-  . BSS.toShort
-  . BSL.toStrict
-  . serialise
+toCardanoApiScript =
+  Shelly.PlutusScript Shelly.PlutusScriptV2
+    . Shelly.PlutusScriptSerialised
+    . BSS.toShort
+    . BSL.toStrict
+    . serialise
 
 scriptHash :: Script -> ScriptHash
 scriptHash =
-    ScriptHash
+  ScriptHash
     . toBuiltin
     . Shelly.serialiseToRawBytes
     . Shelly.hashScript
     . toCardanoApiScript
 
 mintingPolicyHash :: MintingPolicy -> MintingPolicyHash
-mintingPolicyHash
-  = MintingPolicyHash
-  . getScriptHash
-  . scriptHash
-  . getValidator
-  . Validator
-  . getMintingPolicy
+mintingPolicyHash =
+  MintingPolicyHash
+    . getScriptHash
+    . scriptHash
+    . getValidator
+    . Validator
+    . getMintingPolicy
 
 plutonomyMintingPolicyHash :: MintingPolicy -> MintingPolicyHash
 plutonomyMintingPolicyHash =
   let
-    optimizerSettings = Plutonomy.defaultOptimizerOptions
-      { Plutonomy.ooSplitDelay = False
-      , Plutonomy.ooFloatOutLambda  = False
-      }
-
-  in MintingPolicyHash . getScriptHash . scriptHash . getValidator . Plutonomy.optimizeUPLCWith optimizerSettings . Validator . getMintingPolicy
-
+    optimizerSettings =
+      Plutonomy.defaultOptimizerOptions
+        { Plutonomy.ooSplitDelay = False
+        , Plutonomy.ooFloatOutLambda = False
+        }
+   in
+    MintingPolicyHash . getScriptHash . scriptHash . getValidator . Plutonomy.optimizeUPLCWith optimizerSettings . Validator . getMintingPolicy
 
 validatorHash :: Validator -> ValidatorHash
 validatorHash = ValidatorHash . getScriptHash . scriptHash . getValidator

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -7,18 +7,40 @@ module Canonical.Shared (
   validatorHash,
 ) where
 
-import qualified Cardano.Api.Shelley as Shelly
+import Cardano.Api.Shelley qualified as Shelly
 import Codec.Serialise (serialise)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Short as BSS
-import qualified Plutonomy
-import Plutus.V1.Ledger.Scripts
-import Plutus.V1.Ledger.Value
-import Plutus.V2.Ledger.Tx
-import PlutusTx
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as BSS
+import Plutonomy qualified
+import Plutus.V1.Ledger.Scripts (
+  Datum (Datum),
+  DatumHash,
+  MintingPolicy,
+  MintingPolicyHash (MintingPolicyHash),
+  Script,
+  ScriptHash (ScriptHash),
+  Validator (Validator),
+  ValidatorHash (ValidatorHash),
+  getMintingPolicy,
+  getScriptHash,
+  getValidator,
+ )
+import Plutus.V1.Ledger.Value (CurrencySymbol, TokenName, Value (Value))
+import Plutus.V2.Ledger.Tx (OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash))
+import PlutusTx (UnsafeFromData, unsafeFromBuiltinData)
 import PlutusTx.AssocMap (Map)
-import qualified PlutusTx.AssocMap as M
-import PlutusTx.Prelude
+import PlutusTx.AssocMap qualified as M
+import PlutusTx.Prelude (
+  Bool (False),
+  BuiltinData,
+  Maybe (Just),
+  toBuiltin,
+  traceError,
+  ($),
+  (&&),
+  (.),
+  (==),
+ )
 
 type WrappedMintingPolicyType = BuiltinData -> BuiltinData -> ()
 

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -1,4 +1,5 @@
 module Canonical.Shared where
+
 import           Plutus.V1.Ledger.Scripts
 import           Plutus.V1.Ledger.Value
 import           Plutus.V2.Ledger.Tx

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -1,5 +1,8 @@
 module Canonical.Shared (
   WrappedMintingPolicyType,
+  hasBurnedTokens,
+  hasTokenInValue,
+  getTokenNameOfNft,
   countOfTokenInValue,
   convertDatum,
   hasSingleToken,
@@ -41,10 +44,12 @@ import PlutusTx.Prelude (
   Bool (False, True),
   BuiltinByteString,
   BuiltinData,
+  BuiltinString,
   Integer,
   Maybe (Just, Nothing),
   const,
   divide,
+  id,
   maybe,
   modulo,
   otherwise,
@@ -54,6 +59,7 @@ import PlutusTx.Prelude (
   ($),
   (&&),
   (.),
+  (<),
   (<>),
   (==),
  )
@@ -73,12 +79,44 @@ hasSymbolInValue symbol (Value value) = maybe False (const True) (Map.lookup sym
 {-# INLINEABLE hasSingleToken #-}
 hasSingleToken :: Value -> CurrencySymbol -> TokenName -> Bool
 hasSingleToken (Value value) symbol tokenName = case Map.lookup symbol value of
+  Nothing -> False
   Just map' -> case Map.toList map' of
     [(tn, c)] ->
       traceIfFalse "Wrong token name" (tn == tokenName)
         && traceIfFalse "Should be exactly one" (c == 1)
     _ -> traceError "Wrong number of tokens with policy id"
-  Nothing -> False
+
+{- | Return `Maybe TokenName` if the value contains exactly one of the given token
+ Returns `Maybe` in order to be used by the separate
+ `hasTokenInValue` and `getTokenNameOfNft` helpers
+-}
+getTokenNameOfNftMaybe :: CurrencySymbol -> Value -> BuiltinString -> Maybe TokenName
+getTokenNameOfNftMaybe symbol (Value value) specificToken = case Map.lookup symbol value of
+  Nothing -> traceError $ specificToken <> ": Symbol not found"
+  Just map' -> case Map.toList map' of
+    [(tokenName, c)]
+      | c == 1 -> Just tokenName
+      | otherwise -> traceError $ specificToken <> ": Token count should be exactly one"
+    _ -> traceError $ specificToken <> ": Incorrect number of tokens"
+
+-- | Return true if the value contains exactly one of the given token
+hasTokenInValue :: CurrencySymbol -> BuiltinString -> Value -> Bool
+hasTokenInValue symbol specificToken value =
+  maybe False (const True) (getTokenNameOfNftMaybe symbol value specificToken)
+
+-- | Retrive the token name of corresponding symbol from value
+getTokenNameOfNft :: CurrencySymbol -> Value -> BuiltinString -> TokenName
+getTokenNameOfNft symbol value specificToken =
+  maybe (traceError $ specificToken <> ": not found") id (getTokenNameOfNftMaybe symbol value specificToken)
+
+-- | Check that tokens were burned, otherwise trace the specific error
+hasBurnedTokens :: CurrencySymbol -> Value -> BuiltinString -> Bool
+hasBurnedTokens symbol (Value value) specificMessage =
+  case Map.lookup symbol value of
+    Nothing -> traceError $ specificMessage <> ": Symbol not found"
+    Just map' -> case Map.toList map' of
+      [(_, c)] -> traceIfFalse (specificMessage <> ": Count is not less than zero") (c < 0)
+      _ -> traceError $ specificMessage <> ": Wrong number of tokens"
 
 {- | Get the count of tokens with the given `CurrencySymbol`
  and `TokenName` in the given `Value`

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -50,6 +50,7 @@ import PlutusTx.Prelude (
   otherwise,
   toBuiltin,
   traceError,
+  traceIfFalse,
   ($),
   (&&),
   (.),
@@ -71,10 +72,12 @@ hasSymbolInValue symbol (Value value) = maybe False (const True) (Map.lookup sym
 
 {-# INLINEABLE hasSingleToken #-}
 hasSingleToken :: Value -> CurrencySymbol -> TokenName -> Bool
-hasSingleToken (Value v) s t = case Map.lookup s v of
-  Just m -> case Map.toList m of
-    [(t', c)] -> t' == t && c == 1
-    _ -> traceError "wrong number of tokens with policy id"
+hasSingleToken (Value value) symbol tokenName = case Map.lookup symbol value of
+  Just map' -> case Map.toList map' of
+    [(tn, c)] ->
+      traceIfFalse "Wrong token name" (tn == tokenName)
+        && traceIfFalse "Should be exactly one" (c == 1)
+    _ -> traceError "Wrong number of tokens with policy id"
   Nothing -> False
 
 {- | Get the count of tokens with the given `CurrencySymbol`

--- a/src/Canonical/Shared.hs
+++ b/src/Canonical/Shared.hs
@@ -1,10 +1,13 @@
 module Canonical.Shared (
   WrappedMintingPolicyType,
+  countOfTokenInValue,
   convertDatum,
   hasSingleToken,
   hasSymbolInValue,
   hasOneOfToken,
+  integerToByteString,
   isScriptCredential,
+  lovelacesOf,
   mintingPolicyHash,
   plutonomyMintingPolicyHash,
   validatorHash,
@@ -29,22 +32,28 @@ import Plutus.V1.Ledger.Scripts (
   getScriptHash,
   getValidator,
  )
-import Plutus.V1.Ledger.Value (CurrencySymbol, TokenName, Value (Value))
+import Plutus.V1.Ledger.Value (CurrencySymbol, TokenName, Value (Value), adaSymbol, adaToken)
 import Plutus.V2.Ledger.Tx (OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash))
 import PlutusTx (UnsafeFromData, unsafeFromBuiltinData)
 import PlutusTx.AssocMap (Map)
-import PlutusTx.AssocMap qualified as M
+import PlutusTx.AssocMap qualified as Map
 import PlutusTx.Prelude (
   Bool (False, True),
+  BuiltinByteString,
   BuiltinData,
+  Integer,
   Maybe (Just, Nothing),
   const,
+  divide,
   maybe,
+  modulo,
+  otherwise,
   toBuiltin,
   traceError,
   ($),
   (&&),
   (.),
+  (<>),
   (==),
  )
 
@@ -58,20 +67,35 @@ isScriptCredential = \case
 
 {-# INLINEABLE hasSymbolInValue #-}
 hasSymbolInValue :: CurrencySymbol -> Value -> Bool
-hasSymbolInValue symbol (Value value) = maybe False (const True) (M.lookup symbol value)
+hasSymbolInValue symbol (Value value) = maybe False (const True) (Map.lookup symbol value)
 
 {-# INLINEABLE hasSingleToken #-}
 hasSingleToken :: Value -> CurrencySymbol -> TokenName -> Bool
-hasSingleToken (Value v) s t = case M.lookup s v of
-  Just m -> case M.toList m of
+hasSingleToken (Value v) s t = case Map.lookup s v of
+  Just m -> case Map.toList m of
     [(t', c)] -> t' == t && c == 1
     _ -> traceError "wrong number of tokens with policy id"
   Nothing -> False
 
+{- | Get the count of tokens with the given `CurrencySymbol`
+ and `TokenName` in the given `Value`
+-}
+countOfTokenInValue :: CurrencySymbol -> TokenName -> Value -> Integer
+countOfTokenInValue symbol tokenName (Value value) =
+  case Map.lookup symbol value of
+    Nothing -> 0
+    Just map' -> case Map.lookup tokenName map' of
+      Nothing -> 0
+      Just c -> c
+
+-- | Get the count of lovelaces in the given `Value`
+lovelacesOf :: Value -> Integer
+lovelacesOf = countOfTokenInValue adaSymbol adaToken
+
 {-# INLINEABLE hasOneOfToken #-}
 hasOneOfToken :: CurrencySymbol -> TokenName -> Value -> Bool
-hasOneOfToken symbol tokenName (Value value) = case M.lookup symbol value of
-  Just map' -> case M.lookup tokenName map' of
+hasOneOfToken symbol tokenName (Value value) = case Map.lookup symbol value of
+  Just map' -> case Map.lookup tokenName map' of
     Just c -> c == 1
     Nothing -> False
   Nothing -> False
@@ -80,10 +104,27 @@ hasOneOfToken symbol tokenName (Value value) = case M.lookup symbol value of
 convertDatum :: UnsafeFromData a => Map DatumHash Datum -> OutputDatum -> a
 convertDatum infoData datum = unsafeFromBuiltinData $ case datum of
   OutputDatum (Datum dbs) -> dbs
-  OutputDatumHash dh -> case M.lookup dh infoData of
+  OutputDatumHash dh -> case Map.lookup dh infoData of
     Just (Datum dbs) -> dbs
     _ -> traceError "Missing datum"
   NoOutputDatum -> traceError "Missing datum hash or datum"
+
+{-# INLINEABLE integerToByteString #-}
+integerToByteString :: Integer -> BuiltinByteString
+integerToByteString n
+  | n == 0 = "0"
+  | n == 1 = "1"
+  | n == 2 = "2"
+  | n == 3 = "3"
+  | n == 4 = "4"
+  | n == 5 = "5"
+  | n == 6 = "6"
+  | n == 7 = "7"
+  | n == 8 = "8"
+  | n == 9 = "9"
+  | otherwise =
+      integerToByteString (n `divide` 10)
+        <> integerToByteString (n `modulo` 10)
 
 toCardanoApiScript :: Script -> Shelly.Script Shelly.PlutusScriptV2
 toCardanoApiScript =

--- a/src/Canonical/Tally.hs
+++ b/src/Canonical/Tally.hs
@@ -103,7 +103,7 @@ import PlutusTx.Prelude (
  )
 import PlutusTx.Prelude qualified as PlutusTx
 
-data IndexNftDatum = IndexNftDatum
+newtype IndexNftDatum = IndexNftDatum
   { indIndex :: Integer
   }
 
@@ -420,7 +420,7 @@ data TallyTxInInfo = TallyTxInInfo
   , tTxInInfoResolved :: TallyTxOut
   }
 
-data TallyScriptPurpose = TallySpend TxOutRef
+newtype TallyScriptPurpose = TallySpend TxOutRef
 
 data TallyScriptContext = TallyScriptContext
   { tScriptContextTxInfo :: TallyTxInfo

--- a/src/Canonical/Tally.hs
+++ b/src/Canonical/Tally.hs
@@ -1,4 +1,17 @@
-module Canonical.Tally where
+module Canonical.Tally
+  ( IndexValidatorConfig(..)
+  , IndexNftConfig(..)
+  , TallyNftConfig(..)
+  , TallyValidatorConfig(..)
+  , indexScript
+  , indexValidatorHash
+  , tallyIndexNftMinter
+  , tallyIndexNftMinterPolicyId
+  , tallyNftMinter
+  , tallyNftMinterPolicyId
+  , tallyScript
+  , tallyValidatorHash
+  ) where
 
 import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
 import           Codec.Serialise (serialise)

--- a/src/Canonical/Tally.hs
+++ b/src/Canonical/Tally.hs
@@ -30,9 +30,9 @@ import Canonical.Vote (
  )
 import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
 import Codec.Serialise (serialise)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Short as BSS
-import qualified Plutonomy
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as BSS
+import Plutonomy qualified
 import Plutus.V1.Ledger.Address (Address (Address, addressCredential))
 import Plutus.V1.Ledger.Credential (Credential (ScriptCredential))
 import Plutus.V1.Ledger.Interval (before)
@@ -71,12 +71,11 @@ import PlutusTx (
   unstableMakeIsData,
  )
 import PlutusTx.AssocMap (Map)
-import qualified PlutusTx.AssocMap as M
+import PlutusTx.AssocMap qualified as M
 import PlutusTx.Prelude (
   Bool (False, True),
   BuiltinByteString,
   BuiltinData,
-  Eq,
   Integer,
   Maybe (Just, Nothing),
   all,
@@ -102,6 +101,7 @@ import PlutusTx.Prelude (
   (==),
   (||),
  )
+import PlutusTx.Prelude qualified as PlutusTx
 
 data IndexNftDatum = IndexNftDatum
   { indIndex :: Integer
@@ -529,7 +529,7 @@ hasExpectedScripts theInputs theTallyValidator voteValidator =
     traceIfFalse "More than one tally input" onlyOneTallyScript
       && traceIfFalse "Invalid script inputs" onlyTallyOrVote
 
-mapInsertWith :: Eq k => (a -> a -> a) -> k -> a -> Map k a -> Map k a
+mapInsertWith :: PlutusTx.Eq k => (a -> a -> a) -> k -> a -> Map k a -> Map k a
 mapInsertWith f k v xs = case M.lookup k xs of
   Nothing -> M.insert k v xs
   Just v' -> M.insert k (f v v') xs

--- a/src/Canonical/Tally.hs
+++ b/src/Canonical/Tally.hs
@@ -18,6 +18,7 @@ import Canonical.Shared (
   convertDatum,
   hasOneOfToken,
   hasSingleToken,
+  hasSymbolInValue,
   isScriptCredential,
   mintingPolicyHash,
   validatorHash,
@@ -569,9 +570,7 @@ validateTally
           _ -> traceError "Too many vote nfts"
 
       hasVoteWitness :: Value -> Bool
-      hasVoteWitness (Value v) = case M.lookup tdcVoteCurrencySymbol v of
-        Nothing -> False
-        Just _ -> True
+      hasVoteWitness = hasSymbolInValue tdcVoteFungibleCurrencySymbol
 
       thisTallyTokenName :: TokenName
       !thisTallyTokenName = case M.lookup tdcTallyNft (getValue oldValue) of

--- a/src/Canonical/Tally.hs
+++ b/src/Canonical/Tally.hs
@@ -17,9 +17,11 @@ import Canonical.Shared (
   WrappedMintingPolicyType,
   convertDatum,
   countOfTokenInValue,
+  getTokenNameOfNft,
   hasOneOfToken,
   hasSingleToken,
   hasSymbolInValue,
+  hasTokenInValue,
   integerToByteString,
   isScriptCredential,
   mintingPolicyHash,
@@ -129,11 +131,7 @@ mkIndexNftMinter
     } =
     let
       hasWitness :: Value -> Bool
-      hasWitness (Value v) = case M.lookup thisCurrencySymbol v of
-        Just m -> case M.toList m of
-          [(_, c)] -> if c == 1 then True else traceError "wrong token count"
-          _ -> traceError "wrong number of tokens with policy id"
-        _ -> False
+      hasWitness = hasTokenInValue thisCurrencySymbol "IndexNft Minter, hasWitness"
 
       hasUTxO :: Bool
       !hasUTxO = any (\i -> txInInfoOutRef i == incInitialUtxo) txInfoInputs
@@ -550,13 +548,7 @@ validateTally
       hasVoteWitness = hasSymbolInValue tdcVoteFungibleCurrencySymbol
 
       thisTallyTokenName :: TokenName
-      !thisTallyTokenName = case M.lookup tdcTallyNft (getValue oldValue) of
-        Nothing -> traceError "Failed to find tally nft"
-        Just m -> case M.toList m of
-          [(t, c)]
-            | c == 1 -> t
-            | otherwise -> traceError "bad tally nft count"
-          _ -> traceError "wrong number of tally nfts"
+      !thisTallyTokenName = getTokenNameOfNft tdcTallyNft oldValue "Tally Nft"
 
       stepVotes ::
         TallyTxInInfo ->

--- a/src/Canonical/Tally.hs
+++ b/src/Canonical/Tally.hs
@@ -1,115 +1,115 @@
-module Canonical.Tally
-  ( IndexValidatorConfig(..)
-  , IndexNftConfig(..)
-  , TallyNftConfig(..)
-  , TallyValidatorConfig(..)
-  , indexScript
-  , indexValidatorHash
-  , tallyIndexNftMinter
-  , tallyIndexNftMinterPolicyId
-  , tallyNftMinter
-  , tallyNftMinterPolicyId
-  , tallyScript
-  , tallyValidatorHash
-  ) where
+module Canonical.Tally (
+  IndexValidatorConfig (..),
+  IndexNftConfig (..),
+  TallyNftConfig (..),
+  TallyValidatorConfig (..),
+  indexScript,
+  indexValidatorHash,
+  tallyIndexNftMinter,
+  tallyIndexNftMinterPolicyId,
+  tallyNftMinter,
+  tallyNftMinterPolicyId,
+  tallyScript,
+  tallyValidatorHash,
+) where
 
-import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
-import           Codec.Serialise (serialise)
+import Canonical.Shared (
+  WrappedMintingPolicyType,
+  convertDatum,
+  hasSingleToken,
+  mintingPolicyHash,
+  validatorHash,
+ )
+import Canonical.Types (
+  DynamicConfig (DynamicConfig, dcTallyValidator),
+  TallyState (TallyState, tsAgainst, tsFor, tsProposalEndTime),
+ )
+import Canonical.Vote (
+  Vote (Vote, vDirection, vOwner, vProposalTokenName, vReturnAda),
+  VoteDirection (For),
+ )
+import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
+import Codec.Serialise (serialise)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as BSS
-import           Plutus.V2.Ledger.Contexts 
-  ( TxInfo(TxInfo, txInfoMint, txInfoData, txInfoInputs, txInfoOutputs, txInfoReferenceInputs)
-  , ScriptContext(ScriptContext, scriptContextPurpose, scriptContextTxInfo)
-  , ScriptPurpose(Minting, Spending)
-  , TxInInfo(TxInInfo, txInInfoResolved, txInInfoOutRef)
-  , findTxInByTxOutRef
-  , getContinuingOutputs
-  )
-import           Plutus.V1.Ledger.Credential (Credential(ScriptCredential))
-import           Plutus.V1.Ledger.Interval (before)
-import           Plutus.V1.Ledger.Time (POSIXTimeRange)
-import           Plutus.V1.Ledger.Address (Address(Address, addressCredential))
-import           Plutus.V1.Ledger.Scripts 
-  ( ValidatorHash
-  , Validator(Validator)
-  , MintingPolicy
-  , Script
-  , Datum(Datum)
-  , DatumHash
-  , mkMintingPolicyScript
-  , unMintingPolicyScript
-  )
-import           Plutus.V2.Ledger.Tx 
-  ( TxOutRef
-  , TxOut(TxOut, txOutAddress, txOutDatum, txOutValue)
-  , OutputDatum(OutputDatum, OutputDatumHash, NoOutputDatum)
-  )
-import           Plutus.V1.Ledger.Value as V
-import           PlutusTx 
-  ( applyCode
-  , compile
-  , liftCode
-  , unstableMakeIsData
-  , makeIsDataIndexed
-  , makeLift
-  , unsafeFromBuiltinData
-  )
-import qualified PlutusTx.AssocMap as M
-import           PlutusTx.AssocMap (Map)
-import           PlutusTx.Prelude 
-  ( Integer 
-  , Bool(True, False)
-  , BuiltinData
-  , BuiltinByteString
-  , Maybe(Just, Nothing)
-  , Eq
-  , all
-  , any
-  , check
-  , divide
-  , filter
-  , foldr
-  , length
-  , map
-  , mempty
-  , modulo
-  , not
-  , otherwise
-  , traceIfFalse
-  , traceError
-  , (.)
-  , (<>)
-  , (+)
-  , (*)
-  , ($)
-  , (&&)
-  , (==)
-  , (||)
-  )
 import qualified Plutonomy
-import           Canonical.Shared
-  ( WrappedMintingPolicyType
-  , convertDatum
-  , hasSingleToken
-  , mintingPolicyHash
-  , validatorHash
-  )
-import           Canonical.Types
-  ( DynamicConfig(DynamicConfig, dcTallyValidator)
-  , TallyState(TallyState, tsFor, tsAgainst, tsProposalEndTime)
-  )
-import           Canonical.Vote 
-  ( Vote(Vote, vDirection, vOwner, vProposalTokenName, vReturnAda)
-  , VoteDirection(For)
-  )
+import Plutus.V1.Ledger.Address (Address (Address, addressCredential))
+import Plutus.V1.Ledger.Credential (Credential (ScriptCredential))
+import Plutus.V1.Ledger.Interval (before)
+import Plutus.V1.Ledger.Scripts (
+  Datum (Datum),
+  DatumHash,
+  MintingPolicy,
+  Script,
+  Validator (Validator),
+  ValidatorHash,
+  mkMintingPolicyScript,
+  unMintingPolicyScript,
+ )
+import Plutus.V1.Ledger.Time (POSIXTimeRange)
+import Plutus.V1.Ledger.Value as V
+import Plutus.V2.Ledger.Contexts (
+  ScriptContext (ScriptContext, scriptContextPurpose, scriptContextTxInfo),
+  ScriptPurpose (Minting, Spending),
+  TxInInfo (TxInInfo, txInInfoOutRef, txInInfoResolved),
+  TxInfo (TxInfo, txInfoData, txInfoInputs, txInfoMint, txInfoOutputs, txInfoReferenceInputs),
+  findTxInByTxOutRef,
+  getContinuingOutputs,
+ )
+import Plutus.V2.Ledger.Tx (
+  OutputDatum (NoOutputDatum, OutputDatum, OutputDatumHash),
+  TxOut (TxOut, txOutAddress, txOutDatum, txOutValue),
+  TxOutRef,
+ )
+import PlutusTx (
+  applyCode,
+  compile,
+  liftCode,
+  makeIsDataIndexed,
+  makeLift,
+  unsafeFromBuiltinData,
+  unstableMakeIsData,
+ )
+import PlutusTx.AssocMap (Map)
+import qualified PlutusTx.AssocMap as M
+import PlutusTx.Prelude (
+  Bool (False, True),
+  BuiltinByteString,
+  BuiltinData,
+  Eq,
+  Integer,
+  Maybe (Just, Nothing),
+  all,
+  any,
+  check,
+  divide,
+  filter,
+  foldr,
+  length,
+  map,
+  mempty,
+  modulo,
+  not,
+  otherwise,
+  traceError,
+  traceIfFalse,
+  ($),
+  (&&),
+  (*),
+  (+),
+  (.),
+  (<>),
+  (==),
+  (||),
+ )
 
 data IndexNftDatum = IndexNftDatum
   { indIndex :: Integer
   }
 
 data IndexNftConfig = IndexNftConfig
-  { incInitialUtxo    :: TxOutRef
-  , incTokenName      :: TokenName
+  { incInitialUtxo :: TxOutRef
+  , incTokenName :: TokenName
   , incIndexValidator :: ValidatorHash
   }
 
@@ -117,53 +117,55 @@ unstableMakeIsData ''IndexNftDatum
 makeLift ''IndexNftConfig
 
 mkIndexNftMinter :: IndexNftConfig -> BuiltinData -> ScriptContext -> Bool
-mkIndexNftMinter IndexNftConfig {..} _ ScriptContext
-  { scriptContextTxInfo = TxInfo {..}
-  , scriptContextPurpose = Minting thisCurrencySymbol
-  } =
-  let
-    hasWitness :: Value -> Bool
-    hasWitness (Value v) = case M.lookup thisCurrencySymbol v of
-      Just m -> case M.toList m of
-        [(_, c)] -> if c == 1 then True else traceError "wrong token count"
-        _ -> traceError "wrong number of tokens with policy id"
-      _ -> False
+mkIndexNftMinter
+  IndexNftConfig {..}
+  _
+  ScriptContext
+    { scriptContextTxInfo = TxInfo {..}
+    , scriptContextPurpose = Minting thisCurrencySymbol
+    } =
+    let
+      hasWitness :: Value -> Bool
+      hasWitness (Value v) = case M.lookup thisCurrencySymbol v of
+        Just m -> case M.toList m of
+          [(_, c)] -> if c == 1 then True else traceError "wrong token count"
+          _ -> traceError "wrong number of tokens with policy id"
+        _ -> False
 
-    hasUTxO :: Bool
-    !hasUTxO = any (\i -> txInInfoOutRef i == incInitialUtxo) txInfoInputs
+      hasUTxO :: Bool
+      !hasUTxO = any (\i -> txInInfoOutRef i == incInitialUtxo) txInfoInputs
 
-    (!IndexNftDatum{..}, !outputAddress) = case filter (\TxOut {..} -> hasWitness txOutValue) txInfoOutputs of
-      [ TxOut { .. } ] -> (convertDatum txInfoData txOutDatum, txOutAddress)
-      _ -> traceError "Impossible. No minted output."
+      (!IndexNftDatum {..}, !outputAddress) = case filter (\TxOut {..} -> hasWitness txOutValue) txInfoOutputs of
+        [TxOut {..}] -> (convertDatum txInfoData txOutDatum, txOutAddress)
+        _ -> traceError "Impossible. No minted output."
 
-    initialIndexIsZero :: Bool
-    !initialIndexIsZero = indIndex == 0
+      initialIndexIsZero :: Bool
+      !initialIndexIsZero = indIndex == 0
 
-    onlyOneTokenMinted :: Bool
-    !onlyOneTokenMinted =
-      hasSingleToken
-        txInfoMint
-        thisCurrencySymbol
-        incTokenName
+      onlyOneTokenMinted :: Bool
+      !onlyOneTokenMinted =
+        hasSingleToken
+          txInfoMint
+          thisCurrencySymbol
+          incTokenName
 
-    outputIsValidator :: Bool
-    outputIsValidator = addressCredential outputAddress == ScriptCredential incIndexValidator
-
-  in traceIfFalse "Missing significant UTxO!" hasUTxO
-  && traceIfFalse "Wrong mint amount!" onlyOneTokenMinted
-  && traceIfFalse "Initial Index is not zero" initialIndexIsZero
-  && traceIfFalse "Output is not index validator" outputIsValidator
-
+      outputIsValidator :: Bool
+      outputIsValidator = addressCredential outputAddress == ScriptCredential incIndexValidator
+     in
+      traceIfFalse "Missing significant UTxO!" hasUTxO
+        && traceIfFalse "Wrong mint amount!" onlyOneTokenMinted
+        && traceIfFalse "Initial Index is not zero" initialIndexIsZero
+        && traceIfFalse "Output is not index validator" outputIsValidator
 mkIndexNftMinter _ _ _ = traceError "wrong type of script purpose!"
 
 wrappedPolicy :: IndexNftConfig -> WrappedMintingPolicyType
 wrappedPolicy config a b = check (mkIndexNftMinter config a (unsafeFromBuiltinData b))
 
 policy :: IndexNftConfig -> MintingPolicy
-policy cfg = mkMintingPolicyScript $
-  $$(compile [|| \c -> wrappedPolicy c ||])
-  `PlutusTx.applyCode`
-  PlutusTx.liftCode cfg
+policy cfg =
+  mkMintingPolicyScript $
+    $$(compile [||\c -> wrappedPolicy c||])
+      `PlutusTx.applyCode` PlutusTx.liftCode cfg
 
 plutusScript :: IndexNftConfig -> Script
 plutusScript = unMintingPolicyScript . policy
@@ -178,11 +180,11 @@ scriptAsCbor :: IndexNftConfig -> BSL.ByteString
 scriptAsCbor = serialise . validator
 
 tallyIndexNftMinter :: IndexNftConfig -> PlutusScript PlutusScriptV2
-tallyIndexNftMinter
-  = PlutusScriptSerialised
-  . BSS.toShort
-  . BSL.toStrict
-  . scriptAsCbor
+tallyIndexNftMinter =
+  PlutusScriptSerialised
+    . BSS.toShort
+    . BSL.toStrict
+    . scriptAsCbor
 
 -------------------------------------------------------------------------------
 -- Nft Index Validator
@@ -190,88 +192,93 @@ tallyIndexNftMinter
 
 data IndexValidatorConfig = IndexValidatorConfig
   { ivcConfigNftCurrencySymbol :: CurrencySymbol
-  , ivcConfigNftTokenName      :: TokenName
-  , ivcNonce                   :: Integer -- to help with testing
+  , ivcConfigNftTokenName :: TokenName
+  , ivcNonce :: Integer -- to help with testing
   }
 
 makeLift ''IndexValidatorConfig
 
-validateIndex
-  :: IndexValidatorConfig
-  -> IndexNftDatum
-  -> BuiltinData
-  -> ScriptContext
-  -> Bool
+validateIndex ::
+  IndexValidatorConfig ->
+  IndexNftDatum ->
+  BuiltinData ->
+  ScriptContext ->
+  Bool
 validateIndex
   IndexValidatorConfig {..}
-  IndexNftDatum { indIndex = inputIndex}
+  IndexNftDatum {indIndex = inputIndex}
   _
   ctx@ScriptContext
     { scriptContextTxInfo = info@TxInfo {..}
     , scriptContextPurpose = Spending thisOutRef
     } =
-  let
-    scriptValue :: Value
-    !scriptValue = case findTxInByTxOutRef thisOutRef info of
-      Nothing -> traceError "Impossible not input"
-      Just TxInInfo { txInInfoResolved = TxOut {..}} -> txOutValue
+    let
+      scriptValue :: Value
+      !scriptValue = case findTxInByTxOutRef thisOutRef info of
+        Nothing -> traceError "Impossible not input"
+        Just TxInInfo {txInInfoResolved = TxOut {..}} -> txOutValue
 
-    outputValue :: Value
-    (!outputValue, !IndexNftDatum { indIndex = outputIndex }) = case getContinuingOutputs ctx of
-      [TxOut{..}] -> (txOutValue, convertDatum txInfoData txOutDatum)
-      _ -> traceError "wrong number of continuing outputs"
+      outputValue :: Value
+      (!outputValue, !IndexNftDatum {indIndex = outputIndex}) = case getContinuingOutputs ctx of
+        [TxOut {..}] -> (txOutValue, convertDatum txInfoData txOutDatum)
+        _ -> traceError "wrong number of continuing outputs"
 
-    outputValueGreaterThanInputValue :: Bool
-    outputValueGreaterThanInputValue = outputValue `geq` scriptValue
+      outputValueGreaterThanInputValue :: Bool
+      outputValueGreaterThanInputValue = outputValue `geq` scriptValue
 
-    outputDatumIsIncremented :: Bool
-    outputDatumIsIncremented = outputIndex == inputIndex + 1
-
-  in traceIfFalse "output datum is not incremented" outputDatumIsIncremented
-  && traceIfFalse "script value is not returned" outputValueGreaterThanInputValue
-  && ivcNonce == ivcNonce -- to help with testing
-
+      outputDatumIsIncremented :: Bool
+      outputDatumIsIncremented = outputIndex == inputIndex + 1
+     in
+      traceIfFalse "output datum is not incremented" outputDatumIsIncremented
+        && traceIfFalse "script value is not returned" outputValueGreaterThanInputValue
+        && ivcNonce == ivcNonce -- to help with testing
 validateIndex _ _ _ _ = traceError "Wrong script purpose"
 
-wrapValidateIndex
-    :: IndexValidatorConfig
-    -> BuiltinData
-    -> BuiltinData
-    -> BuiltinData
-    -> ()
-wrapValidateIndex cfg x y z = check (
-  validateIndex
-    cfg
-    (unsafeFromBuiltinData x)
-    (unsafeFromBuiltinData y)
-    (unsafeFromBuiltinData z) )
+wrapValidateIndex ::
+  IndexValidatorConfig ->
+  BuiltinData ->
+  BuiltinData ->
+  BuiltinData ->
+  ()
+wrapValidateIndex cfg x y z =
+  check
+    ( validateIndex
+        cfg
+        (unsafeFromBuiltinData x)
+        (unsafeFromBuiltinData y)
+        (unsafeFromBuiltinData z)
+    )
 
 indexValidator :: IndexValidatorConfig -> Validator
-indexValidator cfg = let
-    optimizerSettings = Plutonomy.defaultOptimizerOptions
-      { Plutonomy.ooSplitDelay = False
-      }
-  in Plutonomy.optimizeUPLCWith optimizerSettings $ Plutonomy.validatorToPlutus $ Plutonomy.mkValidatorScript $
-    $$(PlutusTx.compile [|| wrapValidateIndex ||])
-    `applyCode`
-    liftCode cfg
+indexValidator cfg =
+  let
+    optimizerSettings =
+      Plutonomy.defaultOptimizerOptions
+        { Plutonomy.ooSplitDelay = False
+        }
+   in
+    Plutonomy.optimizeUPLCWith optimizerSettings $
+      Plutonomy.validatorToPlutus $
+        Plutonomy.mkValidatorScript $
+          $$(PlutusTx.compile [||wrapValidateIndex||])
+            `applyCode` liftCode cfg
 
 indexValidatorHash :: IndexValidatorConfig -> ValidatorHash
 indexValidatorHash = validatorHash . indexValidator
 
-indexScript :: IndexValidatorConfig ->  PlutusScript PlutusScriptV2
-indexScript
-  = PlutusScriptSerialised
-  . BSS.toShort
-  . BSL.toStrict
-  . serialise
-  . indexValidator
+indexScript :: IndexValidatorConfig -> PlutusScript PlutusScriptV2
+indexScript =
+  PlutusScriptSerialised
+    . BSS.toShort
+    . BSL.toStrict
+    . serialise
+    . indexValidator
 
 -------------------------------------------------------------------------------
 -- Tally Nft Minter
 -------------------------------------------------------------------------------
 
-{-# INLINABLE integerToByteString #-}
+{-# INLINEABLE integerToByteString #-}
 integerToByteString :: Integer -> BuiltinByteString
 integerToByteString n
   | n == 0 = "0"
@@ -284,97 +291,99 @@ integerToByteString n
   | n == 7 = "7"
   | n == 8 = "8"
   | n == 9 = "9"
-  | otherwise
-    =  integerToByteString (n `divide` 10)
-    <> integerToByteString (n `modulo` 10)
-
+  | otherwise =
+      integerToByteString (n `divide` 10)
+        <> integerToByteString (n `modulo` 10)
 
 data TallyNftConfig = TallyNftConfig
-  { tncIndexNftPolicyId        :: CurrencySymbol
-  , tncIndexNftTokenName       :: TokenName
+  { tncIndexNftPolicyId :: CurrencySymbol
+  , tncIndexNftTokenName :: TokenName
   , tncConfigNftCurrencySymbol :: CurrencySymbol
-  , tncConfigNftTokenName      :: TokenName
+  , tncConfigNftTokenName :: TokenName
   }
 
 makeLift ''TallyNftConfig
 
 mkTallyNftMinter :: TallyNftConfig -> BuiltinData -> ScriptContext -> Bool
-mkTallyNftMinter TallyNftConfig {..} _ ScriptContext
-  { scriptContextTxInfo = TxInfo {..}
-  , scriptContextPurpose = Minting thisCurrencySymbol
-  } =
-  let
-    hasConfigurationNft :: Value -> Bool
-    hasConfigurationNft (Value v) = case M.lookup tncConfigNftCurrencySymbol v of
-      Nothing -> False
-      Just m  -> case M.lookup tncConfigNftTokenName m of
+mkTallyNftMinter
+  TallyNftConfig {..}
+  _
+  ScriptContext
+    { scriptContextTxInfo = TxInfo {..}
+    , scriptContextPurpose = Minting thisCurrencySymbol
+    } =
+    let
+      hasConfigurationNft :: Value -> Bool
+      hasConfigurationNft (Value v) = case M.lookup tncConfigNftCurrencySymbol v of
         Nothing -> False
-        Just c -> c == 1
+        Just m -> case M.lookup tncConfigNftTokenName m of
+          Nothing -> False
+          Just c -> c == 1
 
-    DynamicConfig {..} = case filter (hasConfigurationNft . txOutValue . txInInfoResolved) txInfoReferenceInputs of
-      [TxInInfo {txInInfoResolved = TxOut {..}}] -> convertDatum txInfoData txOutDatum
-      _ -> traceError "Too many Config NFT values"
+      DynamicConfig {..} = case filter (hasConfigurationNft . txOutValue . txInInfoResolved) txInfoReferenceInputs of
+        [TxInInfo {txInInfoResolved = TxOut {..}}] -> convertDatum txInfoData txOutDatum
+        _ -> traceError "Too many Config NFT values"
 
-    hasTallyNft :: Value -> Bool
-    hasTallyNft (Value v) = case M.lookup thisCurrencySymbol v of
-      Nothing -> False
-      Just m  -> case M.lookup theTokenName m of
+      hasTallyNft :: Value -> Bool
+      hasTallyNft (Value v) = case M.lookup thisCurrencySymbol v of
         Nothing -> False
-        Just c | c == 1 -> True
-               | otherwise -> traceError "wrong nft count"
+        Just m -> case M.lookup theTokenName m of
+          Nothing -> False
+          Just c
+            | c == 1 -> True
+            | otherwise -> traceError "wrong nft count"
 
-    TxOut { txOutDatum = outputDatum, txOutAddress = outputAddress } = case filter (hasTallyNft . txOutValue) txInfoOutputs of
-      [x] -> x
-      _ -> traceError "wrong number of outputs"
+      TxOut {txOutDatum = outputDatum, txOutAddress = outputAddress} = case filter (hasTallyNft . txOutValue) txInfoOutputs of
+        [x] -> x
+        _ -> traceError "wrong number of outputs"
 
-    TallyState {..} = unsafeFromBuiltinData $ case outputDatum of
-      OutputDatum (Datum dbs) -> dbs
-      OutputDatumHash dh -> case M.lookup dh txInfoData of
-        Just (Datum dbs) -> dbs
-        _ -> traceError "Missing datum"
-      NoOutputDatum -> traceError "Script input missing datum hash"
+      TallyState {..} = unsafeFromBuiltinData $ case outputDatum of
+        OutputDatum (Datum dbs) -> dbs
+        OutputDatumHash dh -> case M.lookup dh txInfoData of
+          Just (Datum dbs) -> dbs
+          _ -> traceError "Missing datum"
+        NoOutputDatum -> traceError "Script input missing datum hash"
 
-    hasIndexNft :: Value -> Bool
-    hasIndexNft (Value v) = case M.lookup tncIndexNftPolicyId v of
-      Nothing -> False
-      Just m  -> case M.lookup tncIndexNftTokenName m of
+      hasIndexNft :: Value -> Bool
+      hasIndexNft (Value v) = case M.lookup tncIndexNftPolicyId v of
         Nothing -> False
-        Just c -> c == 1
+        Just m -> case M.lookup tncIndexNftTokenName m of
+          Nothing -> False
+          Just c -> c == 1
 
-    IndexNftDatum {..} = case filter (hasIndexNft . txOutValue . txInInfoResolved) txInfoInputs of
-      [TxInInfo {txInInfoResolved = TxOut {..}}] -> convertDatum txInfoData txOutDatum
-      _ -> traceError "Too many Index NFT values"
+      IndexNftDatum {..} = case filter (hasIndexNft . txOutValue . txInInfoResolved) txInfoInputs of
+        [TxInInfo {txInInfoResolved = TxOut {..}}] -> convertDatum txInfoData txOutDatum
+        _ -> traceError "Too many Index NFT values"
 
-    theTokenName :: TokenName
-    !theTokenName = TokenName (integerToByteString indIndex)
+      theTokenName :: TokenName
+      !theTokenName = TokenName (integerToByteString indIndex)
 
-    onlyOneTokenMinted :: Bool
-    !onlyOneTokenMinted =
-      hasSingleToken
-        txInfoMint
-        thisCurrencySymbol
-        theTokenName
+      onlyOneTokenMinted :: Bool
+      !onlyOneTokenMinted =
+        hasSingleToken
+          txInfoMint
+          thisCurrencySymbol
+          theTokenName
 
-    tallyIsInitializeToZero :: Bool
-    !tallyIsInitializeToZero = tsFor == 0 && tsAgainst == 0
+      tallyIsInitializeToZero :: Bool
+      !tallyIsInitializeToZero = tsFor == 0 && tsAgainst == 0
 
-    outputOnTallyValidator :: Bool
-    !outputOnTallyValidator = addressCredential outputAddress == ScriptCredential dcTallyValidator
-
-  in traceIfFalse "Token is not on tally validator" outputOnTallyValidator
-  && traceIfFalse "Tally datum is not initialized to zero" tallyIsInitializeToZero
-  && traceIfFalse "Not only one token was minted" onlyOneTokenMinted
-
+      outputOnTallyValidator :: Bool
+      !outputOnTallyValidator = addressCredential outputAddress == ScriptCredential dcTallyValidator
+     in
+      traceIfFalse "Token is not on tally validator" outputOnTallyValidator
+        && traceIfFalse "Tally datum is not initialized to zero" tallyIsInitializeToZero
+        && traceIfFalse "Not only one token was minted" onlyOneTokenMinted
 mkTallyNftMinter _ _ _ = traceError "wrong type of script purpose!"
 
 wrappedPolicyTally :: TallyNftConfig -> WrappedMintingPolicyType
 wrappedPolicyTally config a b = check (mkTallyNftMinter config a (unsafeFromBuiltinData b))
 
 tallyNftPolicy :: TallyNftConfig -> MintingPolicy
-tallyNftPolicy cfg = mkMintingPolicyScript $
-  $$(compile [|| \c -> wrappedPolicyTally c ||])
-  `PlutusTx.applyCode`
-  PlutusTx.liftCode cfg
+tallyNftPolicy cfg =
+  mkMintingPolicyScript $
+    $$(compile [||\c -> wrappedPolicyTally c||])
+      `PlutusTx.applyCode` PlutusTx.liftCode cfg
 
 tallyNftPlutusScript :: TallyNftConfig -> Script
 tallyNftPlutusScript = unMintingPolicyScript . tallyNftPolicy
@@ -389,75 +398,74 @@ tallyNftScriptAsCbor :: TallyNftConfig -> BSL.ByteString
 tallyNftScriptAsCbor = serialise . tallyNftValidator
 
 tallyNftMinter :: TallyNftConfig -> PlutusScript PlutusScriptV2
-tallyNftMinter
-  = PlutusScriptSerialised
-  . BSS.toShort
-  . BSL.toStrict
-  . tallyNftScriptAsCbor
+tallyNftMinter =
+  PlutusScriptSerialised
+    . BSS.toShort
+    . BSL.toStrict
+    . tallyNftScriptAsCbor
 
 -------------------------------------------------------------------------------
 -- Tally Validator
 -------------------------------------------------------------------------------
 
-
 data TallyTxOut = TallyTxOut
-  { tTxOutAddress             :: Address
-  , tTxOutValue               :: Value
-  , tTxOutDatum               :: OutputDatum
-  , tTxOutReferenceScript     :: BuiltinData
+  { tTxOutAddress :: Address
+  , tTxOutValue :: Value
+  , tTxOutDatum :: OutputDatum
+  , tTxOutReferenceScript :: BuiltinData
   }
 
 data TallyTxInInfo = TallyTxInInfo
-  { tTxInInfoOutRef   :: TxOutRef
+  { tTxInInfoOutRef :: TxOutRef
   , tTxInInfoResolved :: TallyTxOut
   }
 
 data TallyScriptPurpose = TallySpend TxOutRef
 
 data TallyScriptContext = TallyScriptContext
-  { tScriptContextTxInfo  :: TallyTxInfo
+  { tScriptContextTxInfo :: TallyTxInfo
   , tScriptContextPurpose :: TallyScriptPurpose
   }
 
 data TallyTxInfo = TallyTxInfo
-  { tTxInfoInputs             :: [TallyTxInInfo]
-  , tTxInfoReferenceInputs    :: [TallyTxInInfo]
-  , tTxInfoOutputs            :: [TallyTxOut]
-  , tTxInfoFee                :: BuiltinData
-  , tTxInfoMint               :: BuiltinData
-  , tTxInfoDCert              :: BuiltinData
-  , tTxInfoWdrl               :: BuiltinData
-  , tTxInfoValidRange         :: POSIXTimeRange
-  , tTxInfoSignatories        :: BuiltinData
-  , tTxInfoRedeemers          :: BuiltinData
-  , tTxInfoData               :: Map DatumHash Datum
-  , tTxInfoId                 :: BuiltinData
+  { tTxInfoInputs :: [TallyTxInInfo]
+  , tTxInfoReferenceInputs :: [TallyTxInInfo]
+  , tTxInfoOutputs :: [TallyTxOut]
+  , tTxInfoFee :: BuiltinData
+  , tTxInfoMint :: BuiltinData
+  , tTxInfoDCert :: BuiltinData
+  , tTxInfoWdrl :: BuiltinData
+  , tTxInfoValidRange :: POSIXTimeRange
+  , tTxInfoSignatories :: BuiltinData
+  , tTxInfoRedeemers :: BuiltinData
+  , tTxInfoData :: Map DatumHash Datum
+  , tTxInfoId :: BuiltinData
   }
 
 data TallyDynamicConfig = TallyDynamicConfig
-  { tdcTallyIndexNft                 :: BuiltinData
-  , tdcTallyNft                      :: CurrencySymbol
-  , tdcTallyValidator                :: BuiltinData
-  , tdcTreasuryValidator             :: BuiltinData
-  , tdcConfigurationValidator        :: BuiltinData
-  , tdcVoteCurrencySymbol            :: CurrencySymbol
-  , tdcVoteTokenName                 :: BuiltinData
-  , tdcVoteValidator                 :: ValidatorHash
-  , tdcUpgradeMajorityPercent        :: BuiltinData
+  { tdcTallyIndexNft :: BuiltinData
+  , tdcTallyNft :: CurrencySymbol
+  , tdcTallyValidator :: BuiltinData
+  , tdcTreasuryValidator :: BuiltinData
+  , tdcConfigurationValidator :: BuiltinData
+  , tdcVoteCurrencySymbol :: CurrencySymbol
+  , tdcVoteTokenName :: BuiltinData
+  , tdcVoteValidator :: ValidatorHash
+  , tdcUpgradeMajorityPercent :: BuiltinData
   , tdcUpgradRelativeMajorityPercent :: BuiltinData
-  , tdcGeneralMajorityPercent        :: BuiltinData
-  , tdcGeneralRelativeMajorityPercent:: BuiltinData
-  , tdcTripMajorityPercent           :: BuiltinData
-  , tdcTripRelativeMajorityPercent   :: BuiltinData
-  , tdcTotalVotes                    :: BuiltinData
-  , tdcVoteNft                       :: CurrencySymbol
-  , tdcVoteFungibleCurrencySymbol    :: CurrencySymbol
-  , tdcVoteFungibleTokenName         :: TokenName
-  , tdcProposalTallyEndOffset        :: BuiltinData
-  , tdcMaxGeneralDisbursement        :: BuiltinData
-  , tdcMaxTripDisbursement           :: BuiltinData
-  , tdcAgentDisbursementPercent      :: BuiltinData
-  , tdcFungibleVotePercent           :: Integer
+  , tdcGeneralMajorityPercent :: BuiltinData
+  , tdcGeneralRelativeMajorityPercent :: BuiltinData
+  , tdcTripMajorityPercent :: BuiltinData
+  , tdcTripRelativeMajorityPercent :: BuiltinData
+  , tdcTotalVotes :: BuiltinData
+  , tdcVoteNft :: CurrencySymbol
+  , tdcVoteFungibleCurrencySymbol :: CurrencySymbol
+  , tdcVoteFungibleTokenName :: TokenName
+  , tdcProposalTallyEndOffset :: BuiltinData
+  , tdcMaxGeneralDisbursement :: BuiltinData
+  , tdcMaxTripDisbursement :: BuiltinData
+  , tdcAgentDisbursementPercent :: BuiltinData
+  , tdcFungibleVotePercent :: Integer
   }
 
 unstableMakeIsData ''TallyDynamicConfig
@@ -468,27 +476,27 @@ unstableMakeIsData ''TallyDynamicConfig
 
 data TallyValidatorConfig = TallyValidatorConfig
   { tvcConfigNftCurrencySymbol :: CurrencySymbol
-  , tvcConfigNftTokenName      :: TokenName
+  , tvcConfigNftTokenName :: TokenName
   }
 
 unstableMakeIsData ''TallyTxOut
 unstableMakeIsData ''TallyTxInInfo
-makeIsDataIndexed  ''TallyScriptPurpose [('TallySpend,1)]
+makeIsDataIndexed ''TallyScriptPurpose [('TallySpend, 1)]
 unstableMakeIsData ''TallyScriptContext
 unstableMakeIsData ''TallyTxInfo
 makeLift ''TallyValidatorConfig
 
 ownValueAndValidator :: [TallyTxInInfo] -> TxOutRef -> (Value, ValidatorHash)
-ownValueAndValidator ins txOutRef = go ins where
-  go = \case
-    [] -> traceError "The impossible happened"
-    TallyTxInInfo {tTxInInfoOutRef, tTxInInfoResolved = TallyTxOut{tTxOutAddress = Address {..}, ..}} :xs ->
-      if tTxInInfoOutRef == txOutRef then
-        case addressCredential of
-          ScriptCredential vh -> (tTxOutValue, vh)
-          _ -> traceError "Impossible. Expected ScriptCredential"
-      else
-        go xs
+ownValueAndValidator ins txOutRef = go ins
+  where
+    go = \case
+      [] -> traceError "The impossible happened"
+      TallyTxInInfo {tTxInInfoOutRef, tTxInInfoResolved = TallyTxOut {tTxOutAddress = Address {..}, ..}} : xs ->
+        if tTxInInfoOutRef == txOutRef
+          then case addressCredential of
+            ScriptCredential vh -> (tTxOutValue, vh)
+            _ -> traceError "Impossible. Expected ScriptCredential"
+          else go xs
 
 isScriptCredential :: Credential -> Bool
 isScriptCredential = \case
@@ -506,7 +514,8 @@ hasExpectedScripts theInputs theTallyValidator voteValidator =
 
     inputCredentials :: [Credential]
     inputCredentials =
-      filter isScriptCredential
+      filter
+        isScriptCredential
         (map (addressCredential . tTxOutAddress . tTxInInfoResolved) theInputs)
 
     onlyTallyOrVote :: Bool
@@ -516,9 +525,9 @@ hasExpectedScripts theInputs theTallyValidator voteValidator =
     onlyOneTallyScript :: Bool
     onlyOneTallyScript =
       length (filter (== tallyCredential) inputCredentials) == 1
-
-  in traceIfFalse "More than one tally input" onlyOneTallyScript
-  && traceIfFalse "Invalid script inputs" onlyTallyOrVote
+   in
+    traceIfFalse "More than one tally input" onlyOneTallyScript
+      && traceIfFalse "Invalid script inputs" onlyTallyOrVote
 
 mapInsertWith :: Eq k => (a -> a -> a) -> k -> a -> Map k a -> Map k a
 mapInsertWith f k v xs = case M.lookup k xs of
@@ -531,193 +540,202 @@ mergePayouts addr value =
 
 -- Optimize this to accum a value
 valuePaidTo' :: [TallyTxOut] -> Address -> Value
-valuePaidTo' outs addr = go mempty outs where
-  go acc [] = acc
-  go acc (TallyTxOut { tTxOutAddress, tTxOutValue } :xs)
-    | addr == tTxOutAddress = go (acc <> tTxOutValue) xs
-    | otherwise = go acc xs
+valuePaidTo' outs addr = go mempty outs
+  where
+    go acc [] = acc
+    go acc (TallyTxOut {tTxOutAddress, tTxOutValue} : xs)
+      | addr == tTxOutAddress = go (acc <> tTxOutValue) xs
+      | otherwise = go acc xs
 
-validateTally
-  :: TallyValidatorConfig
-  -> TallyState
-  -> BuiltinData
-  -> TallyScriptContext
-  -> Bool
+validateTally ::
+  TallyValidatorConfig ->
+  TallyState ->
+  BuiltinData ->
+  TallyScriptContext ->
+  Bool
 validateTally
   TallyValidatorConfig {..}
-  ts@TallyState {tsFor = oldFor, tsAgainst = oldAgainst, tsProposalEndTime }
+  ts@TallyState {tsFor = oldFor, tsAgainst = oldAgainst, tsProposalEndTime}
   _
   TallyScriptContext
     { tScriptContextTxInfo = TallyTxInfo {..}
     , tScriptContextPurpose = TallySpend thisOutRef
     } =
-  let
-    hasConfigurationNft :: Value -> Bool
-    hasConfigurationNft (Value v) = case M.lookup tvcConfigNftCurrencySymbol v of
-      Nothing -> False
-      Just m  -> case M.lookup tvcConfigNftTokenName m of
+    let
+      hasConfigurationNft :: Value -> Bool
+      hasConfigurationNft (Value v) = case M.lookup tvcConfigNftCurrencySymbol v of
         Nothing -> False
-        Just c -> c == 1
+        Just m -> case M.lookup tvcConfigNftTokenName m of
+          Nothing -> False
+          Just c -> c == 1
 
-    TallyDynamicConfig {..} = case filter (hasConfigurationNft . tTxOutValue . tTxInInfoResolved) tTxInfoReferenceInputs of
-      [TallyTxInInfo {tTxInInfoResolved = TallyTxOut {..}}] -> convertDatum tTxInfoData tTxOutDatum
-      _ -> traceError "Too many NFT values"
+      TallyDynamicConfig {..} = case filter (hasConfigurationNft . tTxOutValue . tTxInInfoResolved) tTxInfoReferenceInputs of
+        [TallyTxInInfo {tTxInInfoResolved = TallyTxOut {..}}] -> convertDatum tTxInfoData tTxOutDatum
+        _ -> traceError "Too many NFT values"
 
-    oldValue :: Value
-    thisValidatorHash :: ValidatorHash
+      oldValue :: Value
+      thisValidatorHash :: ValidatorHash
 
-    (!oldValue, !thisValidatorHash) = ownValueAndValidator tTxInfoInputs thisOutRef
-    -- Make sure there is only one tally and many votes
-    expectedScripts :: Bool
-    !expectedScripts = hasExpectedScripts tTxInfoInputs thisValidatorHash tdcVoteValidator
+      (!oldValue, !thisValidatorHash) = ownValueAndValidator tTxInfoInputs thisOutRef
+      -- Make sure there is only one tally and many votes
+      expectedScripts :: Bool
+      !expectedScripts = hasExpectedScripts tTxInfoInputs thisValidatorHash tdcVoteValidator
 
-    hasVoteToken :: Value -> Maybe Value
-    hasVoteToken (Value v) =
-      case filter (\(k, _) -> tdcVoteNft == k) (M.toList v) of
-        [] -> Nothing
-        xs@[_] -> Just (Value (M.fromList xs))
-        _ -> traceError "Too many vote nfts"
+      hasVoteToken :: Value -> Maybe Value
+      hasVoteToken (Value v) =
+        case filter (\(k, _) -> tdcVoteNft == k) (M.toList v) of
+          [] -> Nothing
+          xs@[_] -> Just (Value (M.fromList xs))
+          _ -> traceError "Too many vote nfts"
 
+      hasVoteWitness :: Value -> Bool
+      hasVoteWitness (Value v) = case M.lookup tdcVoteCurrencySymbol v of
+        Nothing -> False
+        Just _ -> True
 
-    hasVoteWitness :: Value -> Bool
-    hasVoteWitness (Value v) = case M.lookup tdcVoteCurrencySymbol v of
-      Nothing -> False
-      Just _ -> True
+      thisTallyTokenName :: TokenName
+      !thisTallyTokenName = case M.lookup tdcTallyNft (getValue oldValue) of
+        Nothing -> traceError "Failed to find tally nft"
+        Just m -> case M.toList m of
+          [(t, c)]
+            | c == 1 -> t
+            | otherwise -> traceError "bad tally nft count"
+          _ -> traceError "wrong number of tally nfts"
 
-    thisTallyTokenName :: TokenName
-    !thisTallyTokenName = case M.lookup tdcTallyNft (getValue oldValue) of
-      Nothing -> traceError "Failed to find tally nft"
-      Just m -> case M.toList m of
-        [(t, c)]
-          | c == 1 -> t
-          | otherwise -> traceError "bad tally nft count"
-        _ -> traceError "wrong number of tally nfts"
+      stepVotes ::
+        TallyTxInInfo ->
+        (Integer, Integer, Map Address Value) ->
+        (Integer, Integer, Map Address Value)
+      stepVotes TallyTxInInfo {tTxInInfoResolved = TallyTxOut {..}} oldAcc@(oldForCount, oldAgainstCount, oldPayoutMap) =
+        case (hasVoteToken tTxOutValue, hasVoteWitness tTxOutValue) of
+          (Just voteNft, True) ->
+            let
+              Vote {..} = convertDatum tTxInfoData tTxOutDatum
 
-    stepVotes
-      :: TallyTxInInfo
-      -> (Integer, Integer, Map Address Value)
-      -> (Integer, Integer, Map Address Value)
-    stepVotes TallyTxInInfo { tTxInInfoResolved = TallyTxOut {..}} oldAcc@(oldForCount, oldAgainstCount, oldPayoutMap) =
-      case (hasVoteToken tTxOutValue, hasVoteWitness tTxOutValue) of
-        (Just voteNft, True) ->
-          let
-            Vote {..} = convertDatum tTxInfoData tTxOutDatum
-
-            -- Count all the dcVoteFungibleCurrencySymbol with dcVoteFungibleTokenName tokens on the vote utxo
-            fungibleTokens :: Integer
-            !fungibleTokens = case M.lookup tdcVoteFungibleCurrencySymbol (getValue tTxOutValue) of
-              Nothing -> 0
-              Just m -> case M.lookup tdcVoteFungibleTokenName m of
+              -- Count all the dcVoteFungibleCurrencySymbol with dcVoteFungibleTokenName tokens on the vote utxo
+              fungibleTokens :: Integer
+              !fungibleTokens = case M.lookup tdcVoteFungibleCurrencySymbol (getValue tTxOutValue) of
                 Nothing -> 0
-                Just c -> c
+                Just m -> case M.lookup tdcVoteFungibleTokenName m of
+                  Nothing -> 0
+                  Just c -> c
 
-            -- Calculate fungible votes using the dcFungibleVotePercent
-            fungibleVotes :: Integer
-            !fungibleVotes = if fungibleTokens == 0 then 0 else (fungibleTokens * tdcFungibleVotePercent) `divide` 1000
+              -- Calculate fungible votes using the dcFungibleVotePercent
+              fungibleVotes :: Integer
+              !fungibleVotes = if fungibleTokens == 0 then 0 else (fungibleTokens * tdcFungibleVotePercent) `divide` 1000
 
-            -- Add the lovelaces and the NFT
-            votePayout :: Value
-            !votePayout = if fungibleTokens == 0
-              then Value (M.insert adaSymbol (M.singleton adaToken vReturnAda) (getValue voteNft))
-              else
-                 Value (M.insert tdcVoteFungibleCurrencySymbol (M.singleton tdcVoteFungibleTokenName fungibleTokens) (M.insert adaSymbol (M.singleton adaToken vReturnAda) (getValue voteNft)))
+              -- Add the lovelaces and the NFT
+              votePayout :: Value
+              !votePayout =
+                if fungibleTokens == 0
+                  then Value (M.insert adaSymbol (M.singleton adaToken vReturnAda) (getValue voteNft))
+                  else Value (M.insert tdcVoteFungibleCurrencySymbol (M.singleton tdcVoteFungibleTokenName fungibleTokens) (M.insert adaSymbol (M.singleton adaToken vReturnAda) (getValue voteNft)))
 
-            checkProposal :: Bool
-            !checkProposal = vProposalTokenName == thisTallyTokenName
+              checkProposal :: Bool
+              !checkProposal = vProposalTokenName == thisTallyTokenName
 
-            newForCount :: Integer
-            !newForCount = oldForCount + if vDirection == For then 1 + fungibleVotes else 0
+              newForCount :: Integer
+              !newForCount = oldForCount + if vDirection == For then 1 + fungibleVotes else 0
 
-            newAgainstCount :: Integer
-            !newAgainstCount = oldAgainstCount + if vDirection == For then 0 else 1 + fungibleVotes
+              newAgainstCount :: Integer
+              !newAgainstCount = oldAgainstCount + if vDirection == For then 0 else 1 + fungibleVotes
 
-            newPayoutMap :: Map Address Value
-            !newPayoutMap = mergePayouts vOwner votePayout oldPayoutMap
+              newPayoutMap :: Map Address Value
+              !newPayoutMap = mergePayouts vOwner votePayout oldPayoutMap
+             in
+              if checkProposal
+                then (newForCount, newAgainstCount, newPayoutMap)
+                else traceError "wrong vote proposal"
+          _ -> oldAcc
 
-          in if checkProposal then
-              (newForCount, newAgainstCount, newPayoutMap)
-             else
-              traceError "wrong vote proposal"
-        _ -> oldAcc
+      -- Collect the votes
+      -- Make sure the votes are for the write proposal
+      -- Make sure the votes have the vote witness
+      forCount :: Integer
+      againstCount :: Integer
+      payoutMap :: Map Address Value
+      (!forCount, !againstCount, !payoutMap) = foldr stepVotes (0, 0, M.empty) tTxInfoInputs
 
-    -- Collect the votes
-    -- Make sure the votes are for the write proposal
-    -- Make sure the votes have the vote witness
-    forCount :: Integer
-    againstCount :: Integer
-    payoutMap :: Map Address Value
-    (!forCount, !againstCount, !payoutMap) = foldr stepVotes (0, 0, M.empty) tTxInfoInputs
+      -- return the vote tokens to the owner
+      addressedIsPaid :: [TallyTxOut] -> (Address, Value) -> Bool
+      addressedIsPaid outputs (addr, value) = valuePaidTo' outputs addr `geq` value
 
-    -- return the vote tokens to the owner
-    addressedIsPaid :: [TallyTxOut] -> (Address, Value) -> Bool
-    addressedIsPaid outputs (addr, value) = valuePaidTo' outputs addr `geq` value
+      voteNftAndAdaToVoters :: Bool
+      !voteNftAndAdaToVoters = all (addressedIsPaid tTxInfoOutputs) (M.toList payoutMap)
 
-    voteNftAndAdaToVoters :: Bool
-    !voteNftAndAdaToVoters = all (addressedIsPaid tTxInfoOutputs) (M.toList payoutMap)
+      tallyingIsInactive :: Bool
+      !tallyingIsInactive = tsProposalEndTime `before` tTxInfoValidRange
 
-    tallyingIsInactive :: Bool
-    !tallyingIsInactive = tsProposalEndTime `before` tTxInfoValidRange
+      voteTokenAreAllBurned :: Bool
+      !voteTokenAreAllBurned = not $ any (hasVoteWitness . tTxOutValue) tTxInfoOutputs
 
-    voteTokenAreAllBurned :: Bool
-    !voteTokenAreAllBurned = not $ any (hasVoteWitness . tTxOutValue) tTxInfoOutputs
+      newDatum :: TallyState
+      newValue :: Value
 
-    newDatum :: TallyState
-    newValue :: Value
+      (!newValue, !newDatum) = case filter
+        ( \TallyTxOut {tTxOutAddress = Address {..}} ->
+            addressCredential == ScriptCredential thisValidatorHash
+        )
+        tTxInfoOutputs of
+        [TallyTxOut {..}] -> (tTxOutValue, convertDatum tTxInfoData tTxOutDatum)
+        _ -> traceError "Wrong number of continuing outputs"
 
-    (!newValue, !newDatum) = case filter (\TallyTxOut{ tTxOutAddress = Address {..}} ->
-        addressCredential == ScriptCredential thisValidatorHash) tTxInfoOutputs of
-      [TallyTxOut {..}] -> (tTxOutValue, convertDatum tTxInfoData tTxOutDatum)
-      _ -> traceError "Wrong number of continuing outputs"
+      newValueIsAtleastAsBigAsOldValue :: Bool
+      !newValueIsAtleastAsBigAsOldValue = newValue `geq` oldValue
 
-    newValueIsAtleastAsBigAsOldValue :: Bool
-    !newValueIsAtleastAsBigAsOldValue = newValue `geq` oldValue
+      -- Tally datum is updated
+      tallyDatumIsUpdated :: Bool
+      !tallyDatumIsUpdated =
+        newDatum
+          == ts
+            { tsFor = oldFor + forCount
+            , tsAgainst = oldAgainst + againstCount
+            }
+     in
+      traceIfFalse "Tally is active" tallyingIsInactive
+        && traceIfFalse "Unexpected scripts" expectedScripts
+        && traceIfFalse "Not all vote tokens and Ada returned" voteNftAndAdaToVoters
+        && traceIfFalse "Not all vote tokens are burned" voteTokenAreAllBurned
+        && traceIfFalse "Tally datum is not updated" tallyDatumIsUpdated
+        && traceIfFalse "Old value is not as big as new value" newValueIsAtleastAsBigAsOldValue
 
-    -- Tally datum is updated
-    tallyDatumIsUpdated :: Bool
-    !tallyDatumIsUpdated = newDatum ==
-      ts { tsFor     = oldFor     + forCount
-         , tsAgainst = oldAgainst + againstCount
-         }
-
-  in traceIfFalse "Tally is active" tallyingIsInactive
-  && traceIfFalse "Unexpected scripts" expectedScripts
-  && traceIfFalse "Not all vote tokens and Ada returned" voteNftAndAdaToVoters
-  && traceIfFalse "Not all vote tokens are burned" voteTokenAreAllBurned
-  && traceIfFalse "Tally datum is not updated" tallyDatumIsUpdated
-  && traceIfFalse "Old value is not as big as new value" newValueIsAtleastAsBigAsOldValue
-
-
-wrapValidateTally
-    :: TallyValidatorConfig
-    -> BuiltinData
-    -> BuiltinData
-    -> BuiltinData
-    -> ()
-wrapValidateTally cfg x y z = check (
-  validateTally
-    cfg
-    (unsafeFromBuiltinData x)
-    (unsafeFromBuiltinData y)
-    (unsafeFromBuiltinData z) )
+wrapValidateTally ::
+  TallyValidatorConfig ->
+  BuiltinData ->
+  BuiltinData ->
+  BuiltinData ->
+  ()
+wrapValidateTally cfg x y z =
+  check
+    ( validateTally
+        cfg
+        (unsafeFromBuiltinData x)
+        (unsafeFromBuiltinData y)
+        (unsafeFromBuiltinData z)
+    )
 
 tallyValidator :: TallyValidatorConfig -> Validator
-tallyValidator cfg = let
-    optimizerSettings = Plutonomy.defaultOptimizerOptions
-      { Plutonomy.ooSplitDelay = False
-      , Plutonomy.ooFloatOutLambda = False
-      }
-  in Plutonomy.optimizeUPLCWith optimizerSettings $ Plutonomy.validatorToPlutus $ Plutonomy.mkValidatorScript $
-    $$(PlutusTx.compile [|| wrapValidateTally ||])
-    `applyCode`
-    liftCode cfg
+tallyValidator cfg =
+  let
+    optimizerSettings =
+      Plutonomy.defaultOptimizerOptions
+        { Plutonomy.ooSplitDelay = False
+        , Plutonomy.ooFloatOutLambda = False
+        }
+   in
+    Plutonomy.optimizeUPLCWith optimizerSettings $
+      Plutonomy.validatorToPlutus $
+        Plutonomy.mkValidatorScript $
+          $$(PlutusTx.compile [||wrapValidateTally||])
+            `applyCode` liftCode cfg
 
 tallyValidatorHash :: TallyValidatorConfig -> ValidatorHash
 tallyValidatorHash = validatorHash . tallyValidator
 
-tallyScript :: TallyValidatorConfig ->  PlutusScript PlutusScriptV2
-tallyScript
-  = PlutusScriptSerialised
-  . BSS.toShort
-  . BSL.toStrict
-  . serialise
-  . tallyValidator
+tallyScript :: TallyValidatorConfig -> PlutusScript PlutusScriptV2
+tallyScript =
+  PlutusScriptSerialised
+    . BSS.toShort
+    . BSL.toStrict
+    . serialise
+    . tallyValidator

--- a/src/Canonical/Treasury.hs
+++ b/src/Canonical/Treasury.hs
@@ -4,7 +4,13 @@ module Canonical.Treasury (
   treasuryValidatorHash,
 ) where
 
-import Canonical.Shared (hasOneOfToken, isScriptCredential, validatorHash)
+import Canonical.Shared (
+  convertDatum,
+  hasOneOfToken,
+  hasSymbolInValue,
+  isScriptCredential,
+  validatorHash,
+ )
 import Canonical.Types (
   DynamicConfig (
     DynamicConfig,
@@ -42,7 +48,7 @@ import Plutus.V1.Ledger.Address (Address (Address, addressCredential))
 import Plutus.V1.Ledger.Credential (Credential (ScriptCredential))
 import Plutus.V1.Ledger.Crypto (PubKeyHash)
 import Plutus.V1.Ledger.Interval (before)
-import Plutus.V1.Ledger.Scripts (Datum (Datum), DatumHash, Validator, ValidatorHash)
+import Plutus.V1.Ledger.Scripts (Datum, DatumHash, Validator, ValidatorHash)
 import Plutus.V1.Ledger.Time (POSIXTime (POSIXTime), POSIXTimeRange)
 import Plutus.V1.Ledger.Value as V
 import Plutus.V2.Ledger.Tx hiding (Mint)
@@ -220,29 +226,17 @@ validateTreasury
       hasConfigurationNft :: Value -> Bool
       hasConfigurationNft = hasOneOfToken tvcConfigNftCurrencySymbol tvcConfigNftTokenName
 
+      hasTallyNft :: Value -> Bool
+      hasTallyNft = hasSymbolInValue dcTallyNft
+
       -- filter the reference inputs for the configuration nft
       DynamicConfig {..} = case filter (hasConfigurationNft . tTxOutValue . tTxInInfoResolved) tTxInfoReferenceInputs of
-        [TreasuryTxInInfo {tTxInInfoResolved = TreasuryTxOut {..}}] -> unsafeFromBuiltinData $ case tTxOutDatum of
-          OutputDatum (Datum dbs) -> dbs
-          OutputDatumHash dh -> case M.lookup dh tTxInfoData of
-            Just (Datum dbs) -> dbs
-            _ -> traceError "Missing datum"
-          NoOutputDatum -> traceError "Script input missing datum hash"
+        [TreasuryTxInInfo {tTxInInfoResolved = TreasuryTxOut {..}}] -> convertDatum tTxInfoData tTxOutDatum
         _ -> traceError "Too many NFT values"
-
-      hasTallyNft :: Value -> Bool
-      hasTallyNft (Value v) = case M.lookup dcTallyNft v of
-        Nothing -> False
-        Just {} -> True
 
       TallyState {..} = case filter (hasTallyNft . tTxOutValue . tTxInInfoResolved) tTxInfoReferenceInputs of
         [] -> traceError "Missing tally NFT"
-        [TreasuryTxInInfo {tTxInInfoResolved = TreasuryTxOut {..}}] -> unsafeFromBuiltinData $ case tTxOutDatum of
-          OutputDatum (Datum dbs) -> dbs
-          OutputDatumHash dh -> case M.lookup dh tTxInfoData of
-            Just (Datum dbs) -> dbs
-            _ -> traceError "Missing datum"
-          NoOutputDatum -> traceError "Script input missing datum hash"
+        [TreasuryTxInInfo {tTxInInfoResolved = TreasuryTxOut {..}}] -> convertDatum tTxInfoData tTxOutDatum
         _ -> traceError "Too many NFT values"
 
       totalVotes :: Integer

--- a/src/Canonical/Treasury.hs
+++ b/src/Canonical/Treasury.hs
@@ -35,9 +35,9 @@ import Canonical.Types (
  )
 import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
 import Codec.Serialise (serialise)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Short as BSS
-import qualified Plutonomy
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as BSS
+import Plutonomy qualified
 import Plutus.V1.Ledger.Address (Address (Address, addressCredential))
 import Plutus.V1.Ledger.Credential (Credential (ScriptCredential))
 import Plutus.V1.Ledger.Crypto (PubKeyHash)
@@ -56,7 +56,7 @@ import PlutusTx (
   unstableMakeIsData,
  )
 import PlutusTx.AssocMap (Map)
-import qualified PlutusTx.AssocMap as M
+import PlutusTx.AssocMap qualified as M
 import PlutusTx.Prelude (
   Bool (False, True),
   BuiltinData,

--- a/src/Canonical/Treasury.hs
+++ b/src/Canonical/Treasury.hs
@@ -9,6 +9,7 @@ import Canonical.Shared (
   hasOneOfToken,
   hasSymbolInValue,
   isScriptCredential,
+  lovelacesOf,
   validatorHash,
  )
 import Canonical.Types (
@@ -167,13 +168,6 @@ getContinuingOutputs' vh outs =
           == ScriptCredential vh
     )
     outs
-
-lovelacesOf :: Value -> Integer
-lovelacesOf (Value v) = case M.lookup adaSymbol v of
-  Nothing -> 0
-  Just m -> case M.lookup adaToken m of
-    Nothing -> 0
-    Just c -> c
 
 ownValueAndValidator :: [TreasuryTxInInfo] -> TxOutRef -> (Value, ValidatorHash)
 ownValueAndValidator ins txOutRef = go ins

--- a/src/Canonical/Treasury.hs
+++ b/src/Canonical/Treasury.hs
@@ -98,7 +98,7 @@ data TreasuryTxInInfo = TreasuryTxInInfo
   , tTxInInfoResolved :: TreasuryTxOut
   }
 
-data TreasuryScriptPurpose = TreasurySpend TxOutRef
+newtype TreasuryScriptPurpose = TreasurySpend TxOutRef
 
 data TreasuryScriptContext = TreasuryScriptContext
   { tScriptContextTxInfo :: TreasuryTxInfo

--- a/src/Canonical/Treasury.hs
+++ b/src/Canonical/Treasury.hs
@@ -8,6 +8,7 @@ import Canonical.Shared (
   convertDatum,
   hasOneOfToken,
   hasSymbolInValue,
+  hasTokenInValue,
   isScriptCredential,
   lovelacesOf,
   validatorHash,
@@ -63,7 +64,6 @@ import PlutusTx (
   unstableMakeIsData,
  )
 import PlutusTx.AssocMap (Map)
-import PlutusTx.AssocMap qualified as M
 import PlutusTx.Prelude (
   Bool (False, True),
   BuiltinData,
@@ -322,11 +322,7 @@ validateTreasury
 
               -- Make sure the upgrade token was minted
               hasUpgradeMinterToken :: Bool
-              !hasUpgradeMinterToken = case M.lookup upgradeMinter (getValue tTxInfoMint) of
-                Nothing -> False
-                Just m -> case M.toList m of
-                  [(_, c)] -> c == 1
-                  _ -> False
+              !hasUpgradeMinterToken = hasTokenInValue upgradeMinter "Treasury Minter" tTxInfoMint
              in
               traceIfFalse "The proposal doesn't have enough votes" hasEnoughVotes
                 && traceIfFalse "Not minting upgrade token" hasUpgradeMinterToken

--- a/src/Canonical/Treasury.hs
+++ b/src/Canonical/Treasury.hs
@@ -1,4 +1,8 @@
-module Canonical.Treasury where
+module Canonical.Treasury
+  ( TreasuryValidatorConfig(..)
+  , treasuryScript
+  , treasuryValidatorHash 
+  ) where
 
 import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
 import           Codec.Serialise (serialise)

--- a/src/Canonical/Treasury.hs
+++ b/src/Canonical/Treasury.hs
@@ -4,7 +4,7 @@ module Canonical.Treasury (
   treasuryValidatorHash,
 ) where
 
-import Canonical.Shared (validatorHash)
+import Canonical.Shared (hasOneOfToken, isScriptCredential, validatorHash)
 import Canonical.Types (
   DynamicConfig (
     DynamicConfig,
@@ -181,11 +181,6 @@ ownValueAndValidator ins txOutRef = go ins
             _ -> traceError "Impossible. Expected ScriptCredential"
           else go xs
 
-isScriptCredential :: Credential -> Bool
-isScriptCredential = \case
-  ScriptCredential _ -> True
-  _ -> False
-
 onlyOneOfThisScript :: [TreasuryTxInInfo] -> ValidatorHash -> TxOutRef -> Bool
 onlyOneOfThisScript ins vh expectedRef = go ins
   where
@@ -223,11 +218,7 @@ validateTreasury
       (!inputValue, !thisValidator) = ownValueAndValidator tTxInfoInputs thisTxRef
 
       hasConfigurationNft :: Value -> Bool
-      hasConfigurationNft (Value v) = case M.lookup tvcConfigNftCurrencySymbol v of
-        Nothing -> False
-        Just m -> case M.lookup tvcConfigNftTokenName m of
-          Nothing -> False
-          Just c -> c == 1
+      hasConfigurationNft = hasOneOfToken tvcConfigNftCurrencySymbol tvcConfigNftTokenName
 
       -- filter the reference inputs for the configuration nft
       DynamicConfig {..} = case filter (hasConfigurationNft . tTxOutValue . tTxInInfoResolved) tTxInfoReferenceInputs of

--- a/src/Canonical/Types.hs
+++ b/src/Canonical/Types.hs
@@ -10,7 +10,8 @@ import Plutus.V1.Ledger.Scripts (ValidatorHash)
 import Plutus.V1.Ledger.Time (POSIXTime)
 import Plutus.V1.Ledger.Value (CurrencySymbol, TokenName)
 import PlutusTx (unstableMakeIsData)
-import PlutusTx.Prelude (Bool (False), Eq, Integer, (&&), (==))
+import PlutusTx.Prelude (Bool (False), Integer, (&&), (==))
+import PlutusTx.Prelude qualified as PlutusTx
 
 data ProposalType
   = Upgrade
@@ -26,7 +27,7 @@ data ProposalType
       , ptTotalTravelCost :: Integer
       }
 
-instance Eq ProposalType where
+instance PlutusTx.Eq ProposalType where
   x == y = case (x, y) of
     (Upgrade a, Upgrade b) -> a == b
     (General a b, General c d) -> a == c && b == d
@@ -40,7 +41,7 @@ data TallyState = TallyState
   , tsAgainst :: Integer
   }
 
-instance Eq TallyState where
+instance PlutusTx.Eq TallyState where
   TallyState
     { tsProposal = xProposal
     , tsProposalEndTime = xProposalEndTime

--- a/src/Canonical/Types.hs
+++ b/src/Canonical/Types.hs
@@ -1,4 +1,9 @@
-module Canonical.Types where
+module Canonical.Types 
+  ( DynamicConfig(..)
+  , ProposalType(..)
+  , TallyState(..)
+  )
+  where
 
 import           Plutus.V1.Ledger.Address (Address)
 import           Plutus.V1.Ledger.Time (POSIXTime)

--- a/src/Canonical/Types.hs
+++ b/src/Canonical/Types.hs
@@ -1,10 +1,11 @@
 module Canonical.Types where
-import           Plutus.V1.Ledger.Address
-import           Plutus.V1.Ledger.Time
-import           Plutus.V1.Ledger.Value
-import           Plutus.V1.Ledger.Scripts
-import           PlutusTx.Prelude
-import           PlutusTx
+
+import           Plutus.V1.Ledger.Address (Address)
+import           Plutus.V1.Ledger.Time (POSIXTime)
+import           Plutus.V1.Ledger.Value (CurrencySymbol, TokenName)
+import           Plutus.V1.Ledger.Scripts (ValidatorHash)
+import           PlutusTx.Prelude (Bool(False), Integer, Eq, (==), (&&))
+import           PlutusTx (unstableMakeIsData)
 
 data ProposalType
   = Upgrade

--- a/src/Canonical/Types.hs
+++ b/src/Canonical/Types.hs
@@ -1,16 +1,16 @@
-module Canonical.Types 
-  ( DynamicConfig(..)
-  , ProposalType(..)
-  , TallyState(..)
-  )
-  where
+module Canonical.Types (
+  DynamicConfig (..),
+  ProposalType (..),
+  TallyState (..),
+)
+where
 
-import           Plutus.V1.Ledger.Address (Address)
-import           Plutus.V1.Ledger.Time (POSIXTime)
-import           Plutus.V1.Ledger.Value (CurrencySymbol, TokenName)
-import           Plutus.V1.Ledger.Scripts (ValidatorHash)
-import           PlutusTx.Prelude (Bool(False), Integer, Eq, (==), (&&))
-import           PlutusTx (unstableMakeIsData)
+import Plutus.V1.Ledger.Address (Address)
+import Plutus.V1.Ledger.Scripts (ValidatorHash)
+import Plutus.V1.Ledger.Time (POSIXTime)
+import Plutus.V1.Ledger.Value (CurrencySymbol, TokenName)
+import PlutusTx (unstableMakeIsData)
+import PlutusTx.Prelude (Bool (False), Eq, Integer, (&&), (==))
 
 data ProposalType
   = Upgrade
@@ -18,12 +18,12 @@ data ProposalType
       }
   | General
       { ptGeneralPaymentAddress :: Address
-      , ptGeneralPaymentValue   :: Integer
+      , ptGeneralPaymentValue :: Integer
       }
   | Trip
       { ptTravelAgentAddress :: Address
-      , ptTravelerAddress    :: Address
-      , ptTotalTravelCost    :: Integer
+      , ptTravelerAddress :: Address
+      , ptTotalTravelCost :: Integer
       }
 
 instance Eq ProposalType where
@@ -31,58 +31,57 @@ instance Eq ProposalType where
     (Upgrade a, Upgrade b) -> a == b
     (General a b, General c d) -> a == c && b == d
     (Trip a b c, Trip d e f) -> a == d && b == e && c == f
-    _                      -> False
+    _ -> False
 
 data TallyState = TallyState
-  { tsProposal        :: ProposalType
+  { tsProposal :: ProposalType
   , tsProposalEndTime :: POSIXTime
-  , tsFor             :: Integer
-  , tsAgainst         :: Integer
+  , tsFor :: Integer
+  , tsAgainst :: Integer
   }
 
 instance Eq TallyState where
   TallyState
-    { tsProposal        = xProposal
+    { tsProposal = xProposal
     , tsProposalEndTime = xProposalEndTime
-    , tsFor             = xFor
-    , tsAgainst         = xAgainst
-    } ==
-      TallyState
-        { tsProposal        = yProposal
-        , tsProposalEndTime = yProposalEndTime
-        , tsFor             = yFor
-        , tsAgainst         = yAgainst
-        } =  xProposal        == yProposal
-          && xProposalEndTime == yProposalEndTime
-          && xFor             == yFor
-          && xAgainst         == yAgainst
-
-
+    , tsFor = xFor
+    , tsAgainst = xAgainst
+    }
+    == TallyState
+      { tsProposal = yProposal
+      , tsProposalEndTime = yProposalEndTime
+      , tsFor = yFor
+      , tsAgainst = yAgainst
+      } =
+      xProposal == yProposal
+        && xProposalEndTime == yProposalEndTime
+        && xFor == yFor
+        && xAgainst == yAgainst
 
 data DynamicConfig = DynamicConfig
-  { dcTallyIndexNft                 :: CurrencySymbol
-  , dcTallyNft                      :: CurrencySymbol
-  , dcTallyValidator                :: ValidatorHash
-  , dcTreasuryValidator             :: ValidatorHash
-  , dcConfigurationValidator        :: ValidatorHash
-  , dcVoteCurrencySymbol            :: CurrencySymbol
-  , dcVoteTokenName                 :: TokenName
-  , dcVoteValidator                 :: ValidatorHash
-  , dcUpgradeMajorityPercent        :: Integer -- times a 1000
+  { dcTallyIndexNft :: CurrencySymbol
+  , dcTallyNft :: CurrencySymbol
+  , dcTallyValidator :: ValidatorHash
+  , dcTreasuryValidator :: ValidatorHash
+  , dcConfigurationValidator :: ValidatorHash
+  , dcVoteCurrencySymbol :: CurrencySymbol
+  , dcVoteTokenName :: TokenName
+  , dcVoteValidator :: ValidatorHash
+  , dcUpgradeMajorityPercent :: Integer -- times a 1000
   , dcUpgradRelativeMajorityPercent :: Integer -- times a 1000
-  , dcGeneralMajorityPercent        :: Integer -- times a 1000
-  , dcGeneralRelativeMajorityPercent:: Integer -- times a 1000
-  , dcTripMajorityPercent           :: Integer -- times a 1000
-  , dcTripRelativeMajorityPercent   :: Integer -- times a 1000
-  , dcTotalVotes                    :: Integer
-  , dcVoteNft                       :: CurrencySymbol
-  , dcVoteFungibleCurrencySymbol    :: CurrencySymbol
-  , dcVoteFungibleTokenName         :: TokenName
-  , dcProposalTallyEndOffset        :: Integer -- in milliseconds
-  , dcMaxGeneralDisbursement        :: Integer
-  , dcMaxTripDisbursement           :: Integer
-  , dcAgentDisbursementPercent      :: Integer -- times a 1000
-  , dcFungibleVotePercent           :: Integer -- times a 1000
+  , dcGeneralMajorityPercent :: Integer -- times a 1000
+  , dcGeneralRelativeMajorityPercent :: Integer -- times a 1000
+  , dcTripMajorityPercent :: Integer -- times a 1000
+  , dcTripRelativeMajorityPercent :: Integer -- times a 1000
+  , dcTotalVotes :: Integer
+  , dcVoteNft :: CurrencySymbol
+  , dcVoteFungibleCurrencySymbol :: CurrencySymbol
+  , dcVoteFungibleTokenName :: TokenName
+  , dcProposalTallyEndOffset :: Integer -- in milliseconds
+  , dcMaxGeneralDisbursement :: Integer
+  , dcMaxTripDisbursement :: Integer
+  , dcAgentDisbursementPercent :: Integer -- times a 1000
+  , dcFungibleVotePercent :: Integer -- times a 1000
   }
 
 unstableMakeIsData ''DynamicConfig

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -1,4 +1,13 @@
-module Canonical.Vote where
+module Canonical.Vote
+  ( Vote(..) 
+  , VoteDirection(..)
+  , VoteMinterConfig(..)
+  , VoteValidatorConfig(..)
+  , voteScript
+  , voteMinter
+  , voteMinterPolicyId
+  , voteValidatorHash
+  ) where
 
 import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
 import           Codec.Serialise (serialise)

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -13,6 +13,7 @@ import Canonical.Shared (
   WrappedMintingPolicyType,
   convertDatum,
   hasOneOfToken,
+  hasSymbolInValue,
   plutonomyMintingPolicyHash,
   validatorHash,
  )
@@ -39,7 +40,7 @@ import Plutus.V1.Ledger.Scripts (
 import Plutus.V1.Ledger.Value (
   CurrencySymbol,
   TokenName,
-  Value (Value),
+  Value,
   adaSymbol,
   adaToken,
   getValue,
@@ -213,9 +214,7 @@ mkVoteMinter
 
         -- Find the reference input with the Tally nft currency symbol
         hasTallyNft :: Value -> Bool
-        hasTallyNft (Value v) = case M.lookup vmdcTallyNft v of
-          Nothing -> False
-          Just _ -> True
+        hasTallyNft = hasSymbolInValue vmdcTallyNft
 
         TallyState {..} = case filter (hasTallyNft . txOutValue . txInInfoResolved) (unsafeFromBuiltinData vmTxInfoReferenceInputs) of
           [TxInInfo {txInInfoResolved = TxOut {..}}] -> convertDatum theData txOutDatum
@@ -416,9 +415,7 @@ validateVote
             !isSignedByOwner = any ((== addressCredential vOwner) . PubKeyCredential) (unsafeFromBuiltinData vTxInfoSignatories :: [PubKeyHash])
 
             hasVoteToken :: Value -> Bool
-            hasVoteToken (Value v) = case M.lookup (unsafeFromBuiltinData vdcVoteCurrencySymbol) v of
-              Nothing -> False
-              Just _ -> True
+            hasVoteToken = hasSymbolInValue (unsafeFromBuiltinData vdcVoteCurrencySymbol)
 
             voteTokenAreAllBurned :: Bool
             !voteTokenAreAllBurned = not $ any (hasVoteToken . vTxOutValue) (unsafeFromBuiltinData vTxInfoOutputs :: [VoteTxOut])

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -18,9 +18,9 @@ import Canonical.Shared (
 import Canonical.Types (TallyState (TallyState, tsProposalEndTime))
 import Cardano.Api.Shelley (PlutusScript (PlutusScriptSerialised), PlutusScriptV2)
 import Codec.Serialise (serialise)
-import qualified Data.ByteString.Lazy as BSL
-import qualified Data.ByteString.Short as BSS
-import qualified Plutonomy
+import Data.ByteString.Lazy qualified as BSL
+import Data.ByteString.Short qualified as BSS
+import Plutonomy qualified
 import Plutus.V1.Ledger.Address (Address, addressCredential)
 import Plutus.V1.Ledger.Credential (Credential (PubKeyCredential, ScriptCredential))
 import Plutus.V1.Ledger.Crypto (PubKeyHash)
@@ -49,11 +49,10 @@ import Plutus.V2.Ledger.Contexts (TxInInfo (TxInInfo, txInInfoResolved))
 import Plutus.V2.Ledger.Tx hiding (Mint)
 import PlutusTx (applyCode, compile, liftCode, makeLift, unsafeFromBuiltinData, unstableMakeIsData)
 import PlutusTx.AssocMap (Map)
-import qualified PlutusTx.AssocMap as M
+import PlutusTx.AssocMap qualified as M
 import PlutusTx.Prelude (
   Bool (False, True),
   BuiltinData,
-  Eq,
   Integer,
   Maybe (Just, Nothing),
   any,
@@ -69,6 +68,7 @@ import PlutusTx.Prelude (
   (==),
   (>),
  )
+import PlutusTx.Prelude qualified as PlutusTx
 
 data VoteMinterConfig = VoteMinterConfig
   { vmcConfigNftCurrencySymbol :: CurrencySymbol
@@ -79,7 +79,7 @@ makeLift ''VoteMinterConfig
 
 data VoteDirection = For | Against
 
-instance Eq VoteDirection where
+instance PlutusTx.Eq VoteDirection where
   x == y = case (x, y) of
     (For, For) -> True
     (Against, Against) -> True

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -115,7 +115,7 @@ data VoteMinterTxInInfo = VoteMinterTxInInfo
   , vmTxInInfoResolved :: VoteMinterTxOut
   }
 
-data VoteMinterScriptPurpose = VMMinting CurrencySymbol
+newtype VoteMinterScriptPurpose = VMMinting CurrencySymbol
 
 data VoteMinterScriptContext = VoteMinterScriptContext
   { vmScriptContextTxInfo :: VoteMinterTxInfo

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -1,22 +1,46 @@
 module Canonical.Vote where
-import           Cardano.Api.Shelley (PlutusScript(..), PlutusScriptV2)
+
+import           Cardano.Api.Shelley (PlutusScript(PlutusScriptSerialised), PlutusScriptV2)
 import           Codec.Serialise (serialise)
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as BSS
-import           Plutus.V1.Ledger.Address
-import           Plutus.V2.Ledger.Contexts
-import           Plutus.V1.Ledger.Crypto
-import           Plutus.V1.Ledger.Credential
-import           Plutus.V1.Ledger.Interval
-import           Plutus.V1.Ledger.Scripts
-import           Plutus.V1.Ledger.Value
+import           Plutus.V1.Ledger.Address (Address, addressCredential)
+import           Plutus.V2.Ledger.Contexts (TxInInfo(TxInInfo, txInInfoResolved))
+import           Plutus.V1.Ledger.Crypto (PubKeyHash)
+import           Plutus.V1.Ledger.Credential (Credential(ScriptCredential, PubKeyCredential))
+import           Plutus.V1.Ledger.Interval (after)
+import           Plutus.V1.Ledger.Scripts 
+  ( Datum
+  , DatumHash
+  , MintingPolicy
+  , Script
+  , Validator(Validator)
+  , ValidatorHash
+  , mkMintingPolicyScript
+  , unMintingPolicyScript
+  )
+import           Plutus.V1.Ledger.Value 
+  ( CurrencySymbol
+  , TokenName
+  , Value(Value)
+  , adaSymbol
+  , adaToken
+  , getValue
+  , mpsSymbol
+  , valueOf
+  )
 import           Plutus.V2.Ledger.Tx hiding (Mint)
 import           PlutusTx.AssocMap (Map)
 import qualified PlutusTx.AssocMap as M
-import           PlutusTx
+import           PlutusTx (applyCode, compile, liftCode, makeLift, unsafeFromBuiltinData, unstableMakeIsData)
 import           PlutusTx.Prelude
-import           Canonical.Shared
-import           Canonical.Types
+import           Canonical.Shared 
+  ( WrappedMintingPolicyType
+  , convertDatum 
+  , plutonomyMintingPolicyHash
+  , validatorHash
+  )
+import           Canonical.Types (TallyState(TallyState, tsProposalEndTime))
 import qualified Plutonomy
 
 data VoteMinterConfig = VoteMinterConfig

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -12,6 +12,7 @@ module Canonical.Vote (
 import Canonical.Shared (
   WrappedMintingPolicyType,
   convertDatum,
+  hasOneOfToken,
   plutonomyMintingPolicyHash,
   validatorHash,
  )
@@ -196,11 +197,7 @@ mkVoteMinter
     Mint ->
       let
         hasConfigurationNft :: Value -> Bool
-        hasConfigurationNft (Value v) = case M.lookup vmcConfigNftCurrencySymbol v of
-          Nothing -> False
-          Just m -> case M.lookup vmcConfigNftTokenName m of
-            Nothing -> False
-            Just c -> c == 1
+        hasConfigurationNft = hasOneOfToken vmcConfigNftCurrencySymbol vmcConfigNftTokenName
 
         theData :: Map DatumHash Datum
         theData = unsafeFromBuiltinData vmTxInfoData
@@ -228,11 +225,7 @@ mkVoteMinter
         !proposalIsActive = tsProposalEndTime `after` (unsafeFromBuiltinData vmTxInfoValidRange)
 
         hasWitness :: Bool
-        !hasWitness = case M.lookup thisCurrencySymbol (getValue voteValue) of
-          Nothing -> False
-          Just m -> case M.lookup vmdcVoteTokenName m of
-            Nothing -> False
-            Just c -> c == 1
+        !hasWitness = hasOneOfToken thisCurrencySymbol vmdcVoteTokenName voteValue
 
         onlyMintedOne :: Bool
         !onlyMintedOne = case M.lookup thisCurrencySymbol (getValue vmTxInfoMint) of
@@ -399,11 +392,7 @@ validateVote
     } =
     let
       hasConfigurationNft :: Value -> Bool
-      hasConfigurationNft (Value v) = case M.lookup vvcConfigNftCurrencySymbol v of
-        Nothing -> False
-        Just m -> case M.lookup vvcConfigNftTokenName m of
-          Nothing -> False
-          Just c -> c == 1
+      hasConfigurationNft = hasOneOfToken vvcConfigNftCurrencySymbol vvcConfigNftTokenName
 
       VoteDynamicConfig {..} = case filter (hasConfigurationNft . vTxOutValue . vTxInInfoResolved) vTxInfoReferenceInputs of
         [VoteTxInInfo {vTxInInfoResolved = VoteTxOut {..}}] -> convertDatum vTxInfoData vTxOutDatum

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -50,7 +50,25 @@ import Plutus.V2.Ledger.Tx hiding (Mint)
 import PlutusTx (applyCode, compile, liftCode, makeLift, unsafeFromBuiltinData, unstableMakeIsData)
 import PlutusTx.AssocMap (Map)
 import qualified PlutusTx.AssocMap as M
-import PlutusTx.Prelude
+import PlutusTx.Prelude (
+  Bool (False, True),
+  BuiltinData,
+  Eq,
+  Integer,
+  Maybe (Just, Nothing),
+  any,
+  check,
+  filter,
+  not,
+  traceError,
+  traceIfFalse,
+  ($),
+  (&&),
+  (.),
+  (<),
+  (==),
+  (>),
+ )
 
 data VoteMinterConfig = VoteMinterConfig
   { vmcConfigNftCurrencySymbol :: CurrencySymbol

--- a/src/Canonical/Vote.hs
+++ b/src/Canonical/Vote.hs
@@ -13,6 +13,7 @@ import Canonical.Shared (
   WrappedMintingPolicyType,
   convertDatum,
   hasOneOfToken,
+  hasSingleToken,
   hasSymbolInValue,
   plutonomyMintingPolicyHash,
   validatorHash,
@@ -227,13 +228,7 @@ mkVoteMinter
         !hasWitness = hasOneOfToken thisCurrencySymbol vmdcVoteTokenName voteValue
 
         onlyMintedOne :: Bool
-        !onlyMintedOne = case M.lookup thisCurrencySymbol (getValue vmTxInfoMint) of
-          Nothing -> traceError "Nothing of this currency symbol minted"
-          Just m -> case M.toList m of
-            [(t, c)] ->
-              traceIfFalse "Wrong number of witnesses minted" (c == 1)
-                && traceIfFalse "Wrong token name" (t == vmdcVoteTokenName)
-            _ -> traceError "Invalid tokens minted"
+        !onlyMintedOne = hasSingleToken vmTxInfoMint thisCurrencySymbol vmdcVoteTokenName
 
         hasVoteNft :: Bool
         !hasVoteNft = case M.lookup vmdcVoteNft (getValue voteValue) of

--- a/triphut.cabal
+++ b/triphut.cabal
@@ -28,6 +28,7 @@ common common-extensions
     CPP
     DeriveGeneric
     DerivingStrategies
+    ImportQualifiedPost
 
 common common-options
   ghc-options:

--- a/triphut.cabal
+++ b/triphut.cabal
@@ -52,6 +52,7 @@ library
     , plutus-ledger-api
     , plutus-tx
     , plutus-tx-plugin
+    , plutus-simple-model
     , serialise
     , plutonomy
 

--- a/triphut.cabal
+++ b/triphut.cabal
@@ -59,13 +59,13 @@ library
   hs-source-dirs:  src
   ghc-options:
     -fobject-code -fno-ignore-interface-pragmas
-    -fno-omit-interface-pragmas -Wno-unused-packages -Wall -Werror
+    -fno-omit-interface-pragmas -Wno-unused-packages -Wall -Werror -Wmissing-export-lists
 
 executable create-sc
   import:         lang
   hs-source-dirs: app
   main-is:        Main.hs
-  ghc-options:    -threaded -rtsopts -with-rtsopts=-T -Wall -Werror
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-T -Wall -Werror -Wmissing-export-lists
   build-depends:
     , cardano-api
     , optparse-generic

--- a/triphut.cabal
+++ b/triphut.cabal
@@ -7,9 +7,10 @@ maintainer:    jonathan@Canonicalllc.com
 build-type:    Simple
 copyright: 2021 Canonical LLC
 
-common lang
-  build-depends:    base ^>=4.14
+common common-lang
   default-language: Haskell2010
+
+common common-extensions
   default-extensions:
     DataKinds
     MultiParamTypeClasses
@@ -26,15 +27,22 @@ common lang
     NoImplicitPrelude
     CPP
     DeriveGeneric
+    DerivingStrategies
 
+common common-options
   ghc-options:
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
-    -Wunused-packages
-    -Wno-partial-fields
+    -Wunused-packages -Wmissing-deriving-strategies
+
+common common-deps
+  build-depends:
+    , base ^>=4.14
+    , cardano-api
+    , plutus-ledger-api
 
 library
-  import:          lang
+  import: common-lang, common-deps, common-options, common-extensions
   exposed-modules:
     Canonical.AlwaysSucceed
     Canonical.ConfigurationNft
@@ -47,27 +55,22 @@ library
   build-depends:
     , aeson
     , bytestring
-    , cardano-api
     , containers
-    , plutus-ledger-api
     , plutus-tx
     , plutus-tx-plugin
-    , plutus-simple-model
     , serialise
     , plutonomy
 
   hs-source-dirs:  src
   ghc-options:
     -fobject-code -fno-ignore-interface-pragmas
-    -fno-omit-interface-pragmas -Wno-unused-packages -Wall -Werror -Wmissing-export-lists
+    -fno-omit-interface-pragmas -Wno-unused-packages
 
 executable create-sc
-  import:         lang
+  import: common-lang, common-deps, common-options, common-extensions
   hs-source-dirs: app
   main-is:        Main.hs
-  ghc-options:    -threaded -rtsopts -with-rtsopts=-T -Wall -Werror -Wmissing-export-lists
+  ghc-options:    -threaded -rtsopts -with-rtsopts=-T
   build-depends:
-    , cardano-api
-    , optparse-generic
     , triphut
-    , plutus-ledger-api
+    , optparse-generic


### PR DESCRIPTION
So this PR does the following:
  * It makes all imports explicit so we can quickly check where something is imported from
  * It makes the exports from a module explicit, so we can see quickly what is public
  * It removes the `unused` `extractDatum` and `extractDatumBytes` functions
  * It adds the `fourmolu` formatter, so we can have consistent style across the codebase, with new contributors too
  * It adds the `ImportQualifiedPost` flag, and changes the qualified imports to have the module name first for clarity
  * It replaces `data` with `newtype` in a number of places where it was possible to do so [see](https://wiki.haskell.org/Performance/Data_types#:~:text=3.3%20Enumerations-,Newtypes,document%20your%20code%20for%20free.)
  * It adds `plutus-simple-model` as a dependency which we will use for testing
  * It removes the clashing `Wno-partial-fields` flag from the .cabal file, and removes the `Werror` flag for now, as the `ProposalType` contains partial fields, this will be fixed in #5 and the `Werror` flag will be added back in then
  * It reduces duplication in a number of places outlined in another smaller comment below
        
        
        