### PR TITLE
Update proposal type

### DIFF
--- a/src/Canonical/Types.hs
+++ b/src/Canonical/Types.hs
@@ -13,26 +13,34 @@ import PlutusTx (unstableMakeIsData)
 import PlutusTx.Prelude (Bool (False), Integer, (&&), (==))
 import PlutusTx.Prelude qualified as PlutusTx
 
+{- | This represents the three possible types of proposals.
+     A `Trip` proposal, a `General` proposal or an `Upgrade` proposal.
+-}
 data ProposalType
-  = Upgrade
-      { ptUpgradeMinter :: CurrencySymbol
-      }
-  | General
-      { ptGeneralPaymentAddress :: Address
-      , ptGeneralPaymentValue :: Integer
-      }
-  | Trip
-      { ptTravelAgentAddress :: Address
-      , ptTravelerAddress :: Address
-      , ptTotalTravelCost :: Integer
-      }
+  = -- | Upgrade a proposal
+    Upgrade
+      CurrencySymbol
+      -- ^ Symbol of the upgrade minting policy
+  | -- | A general proposal
+    General
+      Address
+      -- ^ General payment address
+      Integer
+      -- ^ General payment amount
+  | -- | A trip proposal
+    Trip
+      Address
+      -- ^ Travel agent address
+      Address
+      -- ^ Traveller address
+      Integer
+      -- ^ Total travel cost
 
 instance PlutusTx.Eq ProposalType where
-  x == y = case (x, y) of
-    (Upgrade a, Upgrade b) -> a == b
-    (General a b, General c d) -> a == c && b == d
-    (Trip a b c, Trip d e f) -> a == d && b == e && c == f
-    _ -> False
+  Upgrade a == Upgrade b = a == b
+  General a b == General c d = a == c && b == d
+  Trip a b c == Trip d e f = a == d && b == e && c == f
+  _ == _ = False
 
 data TallyState = TallyState
   { tsProposal :: ProposalType

--- a/triphut.cabal
+++ b/triphut.cabal
@@ -32,7 +32,7 @@ common common-extensions
 
 common common-options
   ghc-options:
-    -Wall -Wcompat -Wincomplete-record-updates
+    -Wall -Werror -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints
     -Wunused-packages -Wmissing-deriving-strategies
 


### PR DESCRIPTION
This changes the `ProposalType` to a normal sum type without records to avoid having partial fields, also added the `-Werror` flag back in now that it's fixed.

~~Marking this as draft for now, will request review again after #4 has been merged~~

Okay this is ready for review again now @Randy1Burrell - I just brought it up to date with main after we merged recent PR.