### PR TITLE
Fix tallying checks

### DIFF
--- a/dao/dao-lib/Dao/Treasury/Script.hs
+++ b/dao/dao-lib/Dao/Treasury/Script.hs
@@ -295,6 +295,7 @@ validateTreasury
                 && traceIfFalse "Disbursing too much" outputValueIsLargeEnough
                 && traceIfFalse "Not paying enough to the travel agent address" paidToTravelAgentAddress
                 && traceIfFalse "Not paying enough to the traveler address" paidToTravelerAddress
+                && traceIfFalse "Tallying not over. Try again later" isAfterTallyEndTime
           ProposalType'General generalPaymentAddress generalPaymentValue ->
             let
               hasEnoughVotes :: Bool
@@ -332,6 +333,7 @@ validateTreasury
               traceIfFalse "The proposal doesn't have enough votes" hasEnoughVotes
                 && traceIfFalse "Disbursing too much" outputValueIsLargeEnough
                 && traceIfFalse "Not paying to the correct address" paidToAddress
+                && traceIfFalse "Tallying not over. Try again later" isAfterTallyEndTime
           ProposalType'Upgrade upgradeMinter ->
             let
               hasEnoughVotes :: Bool

--- a/dao/dao-specs/Spec/Tally/SampleData.hs
+++ b/dao/dao-specs/Spec/Tally/SampleData.hs
@@ -6,12 +6,15 @@ module Spec.Tally.SampleData (
   sampleUpgradeWithEndTimeInFutureTallyStateDatum,
   sampleUpgradeWithEndTimeInPastTallyStateDatum,
   sampleTripWithEndTimeInFutureTallyStateDatum,
+  sampleTripWithEndTimeInPastTallyStateDatum,
   sampleUpgradeWithVotesEndTimeInPastTallyStateDatum,
   sampleUpgradeWithVotesEndTimeInFutureTallyStateDatum,
   sampleGeneralWithEndTimeInFutureTallyStateDatum,
+  sampleGeneralWithEndTimeInPastTallyStateDatum,
   sampleUpgradeNotEnoughVotesEndTimeInPastTallyStateDatum,
   sampleUpgradeNotEnoughVotesEndTimeInFutureTallyStateDatum,
   sampleTripNotEnoughVotesEndTimeInFutureTallyStateDatum,
+  sampleTripNotEnoughVotesEndTimeInPastTallyStateDatum,
 ) where
 
 import LambdaBuffers.ApplicationTypes.Proposal (
@@ -52,6 +55,15 @@ sampleTripNotEnoughVotesEndTimeInFutureTallyStateDatum =
   TallyStateDatum
     { tallyStateDatum'proposal = ProposalType'Trip dummyTravelAgentAddress dummyTravelerPaymentAddress 2
     , tallyStateDatum'proposalEndTime = sampleEndTimeInFuture
+    , tallyStateDatum'for = 1
+    , tallyStateDatum'against = 100
+    }
+
+sampleTripNotEnoughVotesEndTimeInPastTallyStateDatum :: TallyStateDatum
+sampleTripNotEnoughVotesEndTimeInPastTallyStateDatum =
+  TallyStateDatum
+    { tallyStateDatum'proposal = ProposalType'Trip dummyTravelAgentAddress dummyTravelerPaymentAddress 2
+    , tallyStateDatum'proposalEndTime = sampleEndTimeInPast
     , tallyStateDatum'for = 1
     , tallyStateDatum'against = 100
     }
@@ -101,6 +113,15 @@ sampleTripWithEndTimeInFutureTallyStateDatum =
     , tallyStateDatum'against = 3
     }
 
+sampleTripWithEndTimeInPastTallyStateDatum :: TallyStateDatum
+sampleTripWithEndTimeInPastTallyStateDatum =
+  TallyStateDatum
+    { tallyStateDatum'proposal = ProposalType'Trip dummyTravelAgentAddress dummyTravelerPaymentAddress 2
+    , tallyStateDatum'proposalEndTime = sampleEndTimeInPast
+    , tallyStateDatum'for = 5
+    , tallyStateDatum'against = 3
+    }
+
 sampleUpgradeWithVotesEndTimeInPastTallyStateDatum :: TallyStateDatum
 sampleUpgradeWithVotesEndTimeInPastTallyStateDatum =
   TallyStateDatum
@@ -115,6 +136,15 @@ sampleGeneralWithEndTimeInFutureTallyStateDatum =
   TallyStateDatum
     { tallyStateDatum'proposal = sampleGeneralProposalType
     , tallyStateDatum'proposalEndTime = sampleEndTimeInFuture
+    , tallyStateDatum'for = 5
+    , tallyStateDatum'against = 3
+    }
+
+sampleGeneralWithEndTimeInPastTallyStateDatum :: TallyStateDatum
+sampleGeneralWithEndTimeInPastTallyStateDatum =
+  TallyStateDatum
+    { tallyStateDatum'proposal = sampleGeneralProposalType
+    , tallyStateDatum'proposalEndTime = sampleEndTimeInPast
     , tallyStateDatum'for = 5
     , tallyStateDatum'against = 3
     }

--- a/dao/dao-specs/Spec/Tally/Transactions.hs
+++ b/dao/dao-specs/Spec/Tally/Transactions.hs
@@ -2,19 +2,25 @@ module Spec.Tally.Transactions (
   runInitTallyWithEndTimeInPast,
   runInitTallyWithEndTimeInFuture,
   runInitTripTallyWithEndTimeInFuture,
+  runInitTripTallyWithEndTimeInPastNotEnoughVotes,
   runInitUpgradeTallyWithEndTimeInPast,
   runInitGeneralTallyWithEndTimeInFuture,
   runInitUpgradeWithVotesWithEndTimeInFutureTallyStateDatum,
   runInitUpgradeTallyWithEndTimeInPastNotEnoughVotes,
   runInitTripTallyWithEndTimeInFutureNotEnoughVotes,
+  runInitTripTallyWithEndTimeInPast,
+  runInitGeneralTallyWithEndTimeInPast,
 ) where
 
 import Plutus.Model (Run)
 import Spec.SpecUtils (runInitPayToScript)
 import Spec.Tally.SampleData (
   sampleGeneralWithEndTimeInFutureTallyStateDatum,
+  sampleGeneralWithEndTimeInPastTallyStateDatum,
   sampleTripNotEnoughVotesEndTimeInFutureTallyStateDatum,
+  sampleTripNotEnoughVotesEndTimeInPastTallyStateDatum,
   sampleTripWithEndTimeInFutureTallyStateDatum,
+  sampleTripWithEndTimeInPastTallyStateDatum,
   sampleUpgradeNotEnoughVotesEndTimeInPastTallyStateDatum,
   sampleUpgradeWithEndTimeInFutureTallyStateDatum,
   sampleUpgradeWithEndTimeInPastTallyStateDatum,
@@ -31,6 +37,13 @@ runInitTripTallyWithEndTimeInFutureNotEnoughVotes =
     sampleTripNotEnoughVotesEndTimeInFutureTallyStateDatum
     dummyTallyValue
 
+runInitTripTallyWithEndTimeInPastNotEnoughVotes :: Run ()
+runInitTripTallyWithEndTimeInPastNotEnoughVotes =
+  runInitPayToScript
+    tallyNftTypedValidator
+    sampleTripNotEnoughVotesEndTimeInPastTallyStateDatum
+    dummyTallyValue
+
 runInitUpgradeTallyWithEndTimeInPastNotEnoughVotes :: Run ()
 runInitUpgradeTallyWithEndTimeInPastNotEnoughVotes =
   runInitPayToScript
@@ -45,11 +58,25 @@ runInitGeneralTallyWithEndTimeInFuture =
     sampleGeneralWithEndTimeInFutureTallyStateDatum
     dummyTallyValue
 
+runInitGeneralTallyWithEndTimeInPast :: Run ()
+runInitGeneralTallyWithEndTimeInPast =
+  runInitPayToScript
+    tallyNftTypedValidator
+    sampleGeneralWithEndTimeInPastTallyStateDatum
+    dummyTallyValue
+
 runInitTripTallyWithEndTimeInFuture :: Run ()
 runInitTripTallyWithEndTimeInFuture =
   runInitPayToScript
     tallyNftTypedValidator
     sampleTripWithEndTimeInFutureTallyStateDatum
+    dummyTallyValue
+
+runInitTripTallyWithEndTimeInPast :: Run ()
+runInitTripTallyWithEndTimeInPast =
+  runInitPayToScript
+    tallyNftTypedValidator
+    sampleTripWithEndTimeInPastTallyStateDatum
     dummyTallyValue
 
 runInitUpgradeTallyWithEndTimeInPast :: Run ()


### PR DESCRIPTION
This fixes the `validateTreasury` to check that the tallying period has passed for all proposal types, and updates the corresponding tests.